### PR TITLE
Fix naming of identify in german

### DIFF
--- a/locales/de.yml
+++ b/locales/de.yml
@@ -23,7 +23,7 @@ de:
   forgot_password: Passwort vergessen # login form link
   forgot_password_title: Neues Passwort vergeben # heading on /password/new
   get_started: Lass uns loslegen!
-  identify: Anmeldung
+  identify: Identifizieren
   keep_me_signed_in: Angemeldet bleiben
   knowledge_base: Fragen und Antworten
   last_name: Nachname


### PR DESCRIPTION
In the device list the button said "login" instead of "identify". Used the same translation as in `devices.edit.identify`