### PR TITLE
Generic Translations for Trello Public Boards Plugin and others

### DIFF
--- a/lib/trmnl/i18n/locales/custom_plugins/da.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/da.yml
@@ -3,6 +3,10 @@ da:
   custom_plugins:
     today: i dag
     tomorrow: i morgen
+    updated: Updated
+    activity: Activity
+    done: Done
+    due: Due
     deutsche_bahn_departures:
       time: Time
       destination: Destination
@@ -21,7 +25,7 @@ da:
         leap_format_short: LM%{alt_month}
         ym_format: ", %{leap_month_label} %{heavenly_stem} %{earthly_branch}"
         month_labels:
-        -
+        - 
         - M1
         - M2
         - M3
@@ -35,7 +39,7 @@ da:
         - M11
         - M12
         date_labels:
-        -
+        - 
         - '1'
         - '2'
         - '3'
@@ -137,7 +141,7 @@ da:
       hijri:
         ym_format: ", %{month_label} %{alt_year}"
         month_labels:
-        -
+        - 
         - muharram
         - safar
         - rabiʻ I
@@ -153,7 +157,7 @@ da:
       bengali:
         ym_format: ", %{month_label} %{alt_year}"
         month_labels:
-        -
+        - 
         - boishakh
         - joishtho
         - asharh
@@ -169,7 +173,7 @@ da:
       indian:
         ym_format: ", %{month_label} %{alt_year}"
         month_labels:
-        -
+        - 
         - chaitra
         - vaisakha
         - jyaistha

--- a/lib/trmnl/i18n/locales/custom_plugins/de-AT.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/de-AT.yml
@@ -3,6 +3,10 @@ de-AT:
   custom_plugins:
     today: Heute
     tomorrow: Morgen
+    updated: Updated
+    activity: Activity
+    done: Done
+    due: Due
     deutsche_bahn_departures:
       time: Zeit
       destination: Ziel
@@ -21,7 +25,7 @@ de-AT:
         leap_format_short: LM%{alt_month}
         ym_format: ", %{leap_month_label} %{heavenly_stem} %{earthly_branch}"
         month_labels:
-        -
+        - 
         - M1
         - M2
         - M3
@@ -35,7 +39,7 @@ de-AT:
         - M11
         - M12
         date_labels:
-        -
+        - 
         - '1'
         - '2'
         - '3'
@@ -137,7 +141,7 @@ de-AT:
       hijri:
         ym_format: ", %{month_label} %{alt_year}"
         month_labels:
-        -
+        - 
         - Muharram
         - Safar
         - Rabiʻ I
@@ -153,7 +157,7 @@ de-AT:
       bengali:
         ym_format: ", %{month_label} %{alt_year}"
         month_labels:
-        -
+        - 
         - Boishakh
         - Joishtho
         - Asharh
@@ -169,7 +173,7 @@ de-AT:
       indian:
         ym_format: ", %{month_label} %{alt_year}"
         month_labels:
-        -
+        - 
         - Chaitra
         - Vaisakha
         - Jyaishtha

--- a/lib/trmnl/i18n/locales/custom_plugins/de.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/de.yml
@@ -3,6 +3,10 @@ de:
   custom_plugins:
     today: Heute
     tomorrow: Morgen
+    updated: Aktualisiert
+    activity: Aktivität
+    done: Erledigt
+    due: Fällig
     deutsche_bahn_departures:
       time: Zeit
       destination: Ziel
@@ -21,7 +25,7 @@ de:
         leap_format_short: LM%{alt_month}
         ym_format: ", %{leap_month_label} %{heavenly_stem} %{earthly_branch}"
         month_labels:
-        -
+        - 
         - M1
         - M2
         - M3
@@ -35,7 +39,7 @@ de:
         - M11
         - M12
         date_labels:
-        -
+        - 
         - '1'
         - '2'
         - '3'
@@ -137,7 +141,7 @@ de:
       hijri:
         ym_format: ", %{month_label} %{alt_year}"
         month_labels:
-        -
+        - 
         - Muharram
         - Safar
         - Rabiʻ I
@@ -153,7 +157,7 @@ de:
       bengali:
         ym_format: ", %{month_label} %{alt_year}"
         month_labels:
-        -
+        - 
         - Boishakh
         - Joishtho
         - Asharh
@@ -169,7 +173,7 @@ de:
       indian:
         ym_format: ", %{month_label} %{alt_year}"
         month_labels:
-        -
+        - 
         - Chaitra
         - Vaisakha
         - Jyaishtha

--- a/lib/trmnl/i18n/locales/custom_plugins/en.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/en.yml
@@ -3,6 +3,10 @@ en:
   custom_plugins:
     today: today
     tomorrow: tomorrow
+    updated: Updated
+    activity: Activity
+    done: Done
+    due: Due
     deutsche_bahn_departures:
       time: Time
       destination: Destination
@@ -21,7 +25,7 @@ en:
         leap_format_short: LM%{alt_month}
         ym_format: ", %{leap_month_label} %{heavenly_stem} %{earthly_branch}"
         month_labels:
-        -
+        - 
         - M1
         - M2
         - M3
@@ -35,7 +39,7 @@ en:
         - M11
         - M12
         date_labels:
-        -
+        - 
         - '1'
         - '2'
         - '3'
@@ -137,7 +141,7 @@ en:
       hijri:
         ym_format: ", %{month_label} %{alt_year}"
         month_labels:
-        -
+        - 
         - Muharram
         - Safar
         - Rabiʻ I
@@ -153,7 +157,7 @@ en:
       bengali:
         ym_format: ", %{month_label} %{alt_year}"
         month_labels:
-        -
+        - 
         - Boishakh
         - Joishtho
         - Asharh
@@ -169,7 +173,7 @@ en:
       indian:
         ym_format: ", %{month_label} %{alt_year}"
         month_labels:
-        -
+        - 
         - Chaitra
         - Vaisakha
         - Jyaistha

--- a/lib/trmnl/i18n/locales/custom_plugins/es-ES.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/es-ES.yml
@@ -3,6 +3,10 @@ es-ES:
   custom_plugins:
     today: hoy
     tomorrow: mañana
+    updated: Actualizado
+    activity: Actividad
+    done: Realizada
+    due: Pendiente
     deutsche_bahn_departures:
       time: Time
       destination: Destination
@@ -21,7 +25,7 @@ es-ES:
         leap_format_short: LM%{alt_month}
         ym_format: ", %{leap_month_label} %{heavenly_stem} %{earthly_branch}"
         month_labels:
-        -
+        - 
         - M1
         - M2
         - M3
@@ -35,7 +39,7 @@ es-ES:
         - M11
         - M12
         date_labels:
-        -
+        - 
         - '1'
         - '2'
         - '3'
@@ -137,7 +141,7 @@ es-ES:
       hijri:
         ym_format: ", %{month_label} %{alt_year}"
         month_labels:
-        -
+        - 
         - Muharram
         - Safar
         - Rabiʻ I
@@ -153,7 +157,7 @@ es-ES:
       bengali:
         ym_format: ", %{month_label} %{alt_year}"
         month_labels:
-        -
+        - 
         - boishakh
         - joishtho
         - asharh
@@ -169,7 +173,7 @@ es-ES:
       indian:
         ym_format: ", %{month_label} %{alt_year}"
         month_labels:
-        -
+        - 
         - chaitra
         - vaisakha
         - jyaistha

--- a/lib/trmnl/i18n/locales/custom_plugins/fr.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/fr.yml
@@ -3,6 +3,10 @@ fr:
   custom_plugins:
     today: aujourd'hui
     tomorrow: demain
+    updated: Mise à jour
+    activity: Activité
+    done: Réalisé
+    due: A échéance
     deutsche_bahn_departures:
       time: Time
       destination: Destination
@@ -21,7 +25,7 @@ fr:
         leap_format_short: LM%{alt_month}
         ym_format: ", %{leap_month_label} %{heavenly_stem} %{earthly_branch}"
         month_labels:
-        -
+        - 
         - M1
         - M2
         - M3
@@ -35,7 +39,7 @@ fr:
         - M11
         - M12
         date_labels:
-        -
+        - 
         - '1'
         - '2'
         - '3'
@@ -137,7 +141,7 @@ fr:
       hijri:
         ym_format: ", %{month_label} %{alt_year}"
         month_labels:
-        -
+        - 
         - mouharram
         - safar
         - rabia al awal
@@ -153,7 +157,7 @@ fr:
       bengali:
         ym_format: ", %{month_label} %{alt_year}"
         month_labels:
-        -
+        - 
         - boishakh
         - joishtho
         - asharh
@@ -169,7 +173,7 @@ fr:
       indian:
         ym_format: ", %{month_label} %{alt_year}"
         month_labels:
-        -
+        - 
         - chaitra
         - vaishākh
         - jyaishtha

--- a/lib/trmnl/i18n/locales/custom_plugins/he.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/he.yml
@@ -3,6 +3,10 @@ he:
   custom_plugins:
     today: היום
     tomorrow: מחר
+    updated: Updated
+    activity: Activity
+    done: Done
+    due: Due
     deutsche_bahn_departures:
       time: Time
       destination: Destination
@@ -21,7 +25,7 @@ he:
         leap_format_short: LM%{alt_month}
         ym_format: ", %{leap_month_label} %{heavenly_stem} %{earthly_branch}"
         month_labels:
-        -
+        - 
         - M1
         - M2
         - M3
@@ -35,7 +39,7 @@ he:
         - M11
         - M12
         date_labels:
-        -
+        - 
         - '1'
         - '2'
         - '3'
@@ -137,7 +141,7 @@ he:
       hijri:
         ym_format: ", %{month_label} %{alt_year}"
         month_labels:
-        -
+        - 
         - מוחרם
         - צפר
         - רביע אל־אוול
@@ -153,7 +157,7 @@ he:
       bengali:
         ym_format: ", %{month_label} %{alt_year}"
         month_labels:
-        -
+        - 
         - Boishakh
         - Joishtho
         - Asharh
@@ -169,7 +173,7 @@ he:
       indian:
         ym_format: ", %{month_label} %{alt_year}"
         month_labels:
-        -
+        - 
         - צ׳ייטרה
         - וייסקהה
         - ג׳יאסטהה

--- a/lib/trmnl/i18n/locales/custom_plugins/id.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/id.yml
@@ -3,6 +3,10 @@ id:
   custom_plugins:
     today: today
     tomorrow: tomorrow
+    updated: Updated
+    activity: Activity
+    done: Done
+    due: Due
     deutsche_bahn_departures:
       time: Time
       destination: Destination
@@ -21,7 +25,7 @@ id:
         leap_format_short: LM%{alt_month}
         ym_format: ", %{leap_month_label} %{heavenly_stem} %{earthly_branch}"
         month_labels:
-        -
+        - 
         - M1
         - M2
         - M3
@@ -35,7 +39,7 @@ id:
         - M11
         - M12
         date_labels:
-        -
+        - 
         - '1'
         - '2'
         - '3'
@@ -137,7 +141,7 @@ id:
       hijri:
         ym_format: ", %{month_label} %{alt_year}"
         month_labels:
-        -
+        - 
         - Muharam
         - Safar
         - Rabiulawal
@@ -153,7 +157,7 @@ id:
       bengali:
         ym_format: ", %{month_label} %{alt_year}"
         month_labels:
-        -
+        - 
         - Boishakh
         - Joishtho
         - Asharh
@@ -169,7 +173,7 @@ id:
       indian:
         ym_format: ", %{month_label} %{alt_year}"
         month_labels:
-        -
+        - 
         - Chaitra
         - Vaisakha
         - Jyaistha

--- a/lib/trmnl/i18n/locales/custom_plugins/it.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/it.yml
@@ -3,6 +3,10 @@ it:
   custom_plugins:
     today: Oggi
     tomorrow: Domani
+    updated: Aggiornato
+    activity: Attività
+    done: Finito
+    due: Scadenza
     deutsche_bahn_departures:
       time: Time
       destination: Destination
@@ -21,7 +25,7 @@ it:
         leap_format_short: LM%{alt_month}
         ym_format: ", %{leap_month_label} %{heavenly_stem} %{earthly_branch}"
         month_labels:
-        -
+        - 
         - M1
         - M2
         - M3
@@ -35,7 +39,7 @@ it:
         - M11
         - M12
         date_labels:
-        -
+        - 
         - '1'
         - '2'
         - '3'
@@ -137,7 +141,7 @@ it:
       hijri:
         ym_format: ", %{month_label} %{alt_year}"
         month_labels:
-        -
+        - 
         - Muharram
         - Safar
         - Rabiʻ I
@@ -153,7 +157,7 @@ it:
       bengali:
         ym_format: ", %{month_label} %{alt_year}"
         month_labels:
-        -
+        - 
         - Boishakh
         - Joishtho
         - Asharh
@@ -169,7 +173,7 @@ it:
       indian:
         ym_format: ", %{month_label} %{alt_year}"
         month_labels:
-        -
+        - 
         - Chaitra
         - Vaisakha
         - Jyaishtha

--- a/lib/trmnl/i18n/locales/custom_plugins/ja.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/ja.yml
@@ -3,6 +3,10 @@ ja:
   custom_plugins:
     today: 今日
     tomorrow: 明日
+    updated: Updated
+    activity: Activity
+    done: Done
+    due: Due
     deutsche_bahn_departures:
       time: Time
       destination: Destination
@@ -21,7 +25,7 @@ ja:
         leap_format_short: LM%{alt_month}
         ym_format: ", %{heavenly_stem}%{earthly_branch}年%{leap_month_label}"
         month_labels:
-        -
+        - 
         - 一月
         - 二月
         - 三月
@@ -35,7 +39,7 @@ ja:
         - 十一月
         - 十二月
         date_labels:
-        -
+        - 
         - '1'
         - '2'
         - '3'
@@ -137,7 +141,7 @@ ja:
       hijri:
         ym_format: ", %{month_label} %{alt_year}"
         month_labels:
-        -
+        - 
         - Muharram
         - Safar
         - Rabiʻ I
@@ -153,7 +157,7 @@ ja:
       bengali:
         ym_format: ", %{month_label} %{alt_year}"
         month_labels:
-        -
+        - 
         - Boishakh
         - Joishtho
         - Asharh
@@ -169,7 +173,7 @@ ja:
       indian:
         ym_format: ", %{month_label} %{alt_year}"
         month_labels:
-        -
+        - 
         - Chaitra
         - Vaisakha
         - Jyaistha

--- a/lib/trmnl/i18n/locales/custom_plugins/ko.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/ko.yml
@@ -3,6 +3,10 @@ ko:
   custom_plugins:
     today: 오늘
     tomorrow: 내일
+    updated: Updated
+    activity: Activity
+    done: Done
+    due: Due
     deutsche_bahn_departures:
       time: Time
       destination: Destination
@@ -21,7 +25,7 @@ ko:
         leap_format_short: LM%{alt_month}
         ym_format: ", %{heavenly_stem}%{earthly_branch}년 %{leap_month_label}"
         month_labels:
-        -
+        - 
         - 1월
         - 2월
         - 3월
@@ -35,7 +39,7 @@ ko:
         - 11월
         - 12월
         date_labels:
-        -
+        - 
         - '1'
         - '2'
         - '3'
@@ -137,7 +141,7 @@ ko:
       hijri:
         ym_format: ", %{month_label} %{alt_year}"
         month_labels:
-        -
+        - 
         - Muharram
         - Safar
         - Rabiʻ I
@@ -153,7 +157,7 @@ ko:
       bengali:
         ym_format: ", %{month_label} %{alt_year}"
         month_labels:
-        -
+        - 
         - Boishakh
         - Joishtho
         - Asharh
@@ -169,7 +173,7 @@ ko:
       indian:
         ym_format: ", %{month_label} %{alt_year}"
         month_labels:
-        -
+        - 
         - Chaitra
         - Vaisakha
         - Jyaistha

--- a/lib/trmnl/i18n/locales/custom_plugins/nl.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/nl.yml
@@ -3,6 +3,10 @@ nl:
   custom_plugins:
     today: vandaag
     tomorrow: morgen
+    updated: Bijgewerkt
+    activity: Activiteit
+    done: Gedaan
+    due: Verschuldigd
     deutsche_bahn_departures:
       time: Time
       destination: Destination
@@ -21,7 +25,7 @@ nl:
         leap_format_short: LM%{alt_month}
         ym_format: ", %{leap_month_label} %{heavenly_stem} %{earthly_branch}"
         month_labels:
-        -
+        - 
         - M1
         - M2
         - M3
@@ -35,7 +39,7 @@ nl:
         - M11
         - M12
         date_labels:
-        -
+        - 
         - '1'
         - '2'
         - '3'
@@ -137,7 +141,7 @@ nl:
       hijri:
         ym_format: ", %{month_label} %{alt_year}"
         month_labels:
-        -
+        - 
         - Moeharram
         - Safar
         - Rabiʻa al awal
@@ -153,7 +157,7 @@ nl:
       bengali:
         ym_format: ", %{month_label} %{alt_year}"
         month_labels:
-        -
+        - 
         - Boishakh
         - Joishtho
         - Asharh
@@ -169,7 +173,7 @@ nl:
       indian:
         ym_format: ", %{month_label} %{alt_year}"
         month_labels:
-        -
+        - 
         - Chaitra
         - Vaishakha
         - Jyeshtha

--- a/lib/trmnl/i18n/locales/custom_plugins/pl.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/pl.yml
@@ -3,6 +3,10 @@ pl:
   custom_plugins:
     today: today
     tomorrow: tomorrow
+    updated: Updated
+    activity: Activity
+    done: Done
+    due: Due
     deutsche_bahn_departures:
       time: Time
       destination: Destination
@@ -21,7 +25,7 @@ pl:
         leap_format_short: LM%{alt_month}
         ym_format: ", %{leap_month_label} %{heavenly_stem} %{earthly_branch}"
         month_labels:
-        -
+        - 
         - M1
         - M2
         - M3
@@ -35,7 +39,7 @@ pl:
         - M11
         - M12
         date_labels:
-        -
+        - 
         - '1'
         - '2'
         - '3'
@@ -137,7 +141,7 @@ pl:
       hijri:
         ym_format: ", %{month_label} %{alt_year}"
         month_labels:
-        -
+        - 
         - Muharram
         - Safar
         - Rabiʻ I
@@ -153,7 +157,7 @@ pl:
       bengali:
         ym_format: ", %{month_label} %{alt_year}"
         month_labels:
-        -
+        - 
         - Boishakh
         - Joishtho
         - Asharh
@@ -169,7 +173,7 @@ pl:
       indian:
         ym_format: ", %{month_label} %{alt_year}"
         month_labels:
-        -
+        - 
         - Chaitra
         - Vaisakha
         - Jyaistha

--- a/lib/trmnl/i18n/locales/custom_plugins/pt-BR.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/pt-BR.yml
@@ -3,6 +3,10 @@ pt-BR:
   custom_plugins:
     today: hoje
     tomorrow: amanhã
+    updated: Updated
+    activity: Activity
+    done: Done
+    due: Due
     deutsche_bahn_departures:
       time: Time
       destination: Destination
@@ -21,7 +25,7 @@ pt-BR:
         leap_format_short: LM%{alt_month}
         ym_format: ", %{leap_month_label} %{heavenly_stem} %{earthly_branch}"
         month_labels:
-        -
+        - 
         - M1
         - M2
         - M3
@@ -35,7 +39,7 @@ pt-BR:
         - M11
         - M12
         date_labels:
-        -
+        - 
         - '1'
         - '2'
         - '3'
@@ -137,7 +141,7 @@ pt-BR:
       hijri:
         ym_format: ", %{month_label} %{alt_year}"
         month_labels:
-        -
+        - 
         - Muharram
         - Safar
         - Rabiʻ I
@@ -153,7 +157,7 @@ pt-BR:
       bengali:
         ym_format: ", %{month_label} %{alt_year}"
         month_labels:
-        -
+        - 
         - Boishakh
         - Joishtho
         - Asharh
@@ -169,7 +173,7 @@ pt-BR:
       indian:
         ym_format: ", %{month_label} %{alt_year}"
         month_labels:
-        -
+        - 
         - Chaitra
         - Vaisakha
         - Jyaistha

--- a/lib/trmnl/i18n/locales/custom_plugins/raw.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/raw.yml
@@ -3,6 +3,10 @@ raw:
   custom_plugins:
     today: today
     tomorrow: tomorrow
+    updated: custom_plugins.updated
+    activity: custom_plugins.activity
+    done: custom_plugins.done
+    due: custom_plugins.due
     deutsche_bahn_departures:
       time: Time
       destination: Destination
@@ -21,7 +25,7 @@ raw:
         leap_format_short: LM%{alt_month}
         ym_format: ", %{leap_month_label} %{heavenly_stem} %{earthly_branch}"
         month_labels:
-        -
+        - 
         - M1
         - M2
         - M3
@@ -35,7 +39,7 @@ raw:
         - M11
         - M12
         date_labels:
-        -
+        - 
         - '1'
         - '2'
         - '3'
@@ -137,7 +141,7 @@ raw:
       hijri:
         ym_format: ", %{month_label} %{alt_year}"
         month_labels:
-        -
+        - 
         - Muharram
         - Safar
         - Rabiʻ I
@@ -153,7 +157,7 @@ raw:
       bengali:
         ym_format: ", %{month_label} %{alt_year}"
         month_labels:
-        -
+        - 
         - Boishakh
         - Joishtho
         - Asharh
@@ -169,7 +173,7 @@ raw:
       indian:
         ym_format: ", %{month_label} %{alt_year}"
         month_labels:
-        -
+        - 
         - Chaitra
         - Vaisakha
         - Jyaistha

--- a/lib/trmnl/i18n/locales/custom_plugins/sv.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/sv.yml
@@ -3,6 +3,10 @@ sv:
   custom_plugins:
     today: today
     tomorrow: tomorrow
+    updated: Updated
+    activity: Activity
+    done: Done
+    due: Due
     deutsche_bahn_departures:
       time: Time
       destination: Destination
@@ -21,7 +25,7 @@ sv:
         leap_format_short: LM%{alt_month}
         ym_format: ", %{leap_month_label} %{heavenly_stem} %{earthly_branch}"
         month_labels:
-        -
+        - 
         - M1
         - M2
         - M3
@@ -35,7 +39,7 @@ sv:
         - M11
         - M12
         date_labels:
-        -
+        - 
         - '1'
         - '2'
         - '3'
@@ -137,7 +141,7 @@ sv:
       hijri:
         ym_format: ", %{month_label} %{alt_year}"
         month_labels:
-        -
+        - 
         - Muharram
         - Safar
         - Rabiʻ I
@@ -153,7 +157,7 @@ sv:
       bengali:
         ym_format: ", %{month_label} %{alt_year}"
         month_labels:
-        -
+        - 
         - Boishakh
         - Joishtho
         - Asharh
@@ -169,7 +173,7 @@ sv:
       indian:
         ym_format: ", %{month_label} %{alt_year}"
         month_labels:
-        -
+        - 
         - Chaitra
         - Vaisakha
         - Jyaistha

--- a/lib/trmnl/i18n/locales/custom_plugins/uk.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/uk.yml
@@ -3,6 +3,10 @@ uk:
   custom_plugins:
     today: today
     tomorrow: tomorrow
+    updated: Updated
+    activity: Activity
+    done: Done
+    due: Due
     deutsche_bahn_departures:
       time: Time
       destination: Destination
@@ -21,7 +25,7 @@ uk:
         leap_format_short: LM%{alt_month}
         ym_format: ", %{leap_month_label} %{heavenly_stem} %{earthly_branch}"
         month_labels:
-        -
+        - 
         - M1
         - M2
         - M3
@@ -35,7 +39,7 @@ uk:
         - M11
         - M12
         date_labels:
-        -
+        - 
         - '1'
         - '2'
         - '3'
@@ -137,7 +141,7 @@ uk:
       hijri:
         ym_format: ", %{month_label} %{alt_year}"
         month_labels:
-        -
+        - 
         - мухаррам
         - сафар
         - рабі I
@@ -153,7 +157,7 @@ uk:
       bengali:
         ym_format: ", %{month_label} %{alt_year}"
         month_labels:
-        -
+        - 
         - Boishakh
         - Joishtho
         - Asharh
@@ -169,7 +173,7 @@ uk:
       indian:
         ym_format: ", %{month_label} %{alt_year}"
         month_labels:
-        -
+        - 
         - чайтра
         - вайсакха
         - джайстха

--- a/lib/trmnl/i18n/locales/custom_plugins/zh-CN.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/zh-CN.yml
@@ -3,6 +3,10 @@ zh-CN:
   custom_plugins:
     today: today
     tomorrow: tomorrow
+    updated: Updated
+    activity: Activity
+    done: Done
+    due: Due
     deutsche_bahn_departures:
       time: Time
       destination: Destination
@@ -21,7 +25,7 @@ zh-CN:
         leap_format_short: 闰%{month_label}
         ym_format: ", %{heavenly_stem}%{earthly_branch}%{zodiac_animal}年%{leap_month_label}"
         month_labels:
-        -
+        - 
         - 正月
         - 二月
         - 三月
@@ -35,7 +39,7 @@ zh-CN:
         - 十一月
         - 腊月
         date_labels:
-        -
+        - 
         - 初一
         - 初二
         - 初三
@@ -175,7 +179,7 @@ zh-CN:
       hijri:
         ym_format: ", %{month_label} %{alt_year}"
         month_labels:
-        -
+        - 
         - Muharram
         - Safar
         - Rabiʻ I
@@ -191,7 +195,7 @@ zh-CN:
       bengali:
         ym_format: ", %{month_label} %{alt_year}"
         month_labels:
-        -
+        - 
         - Boishakh
         - Joishtho
         - Asharh
@@ -207,7 +211,7 @@ zh-CN:
       indian:
         ym_format: ", %{month_label} %{alt_year}"
         month_labels:
-        -
+        - 
         - Chaitra
         - Vaisakha
         - Jyaistha

--- a/lib/trmnl/i18n/locales/custom_plugins/zh-HK.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/zh-HK.yml
@@ -3,6 +3,10 @@ zh-HK:
   custom_plugins:
     today: 今日
     tomorrow: 明日
+    updated: Updated
+    activity: Activity
+    done: Done
+    due: Due
     deutsche_bahn_departures:
       time: Time
       destination: Destination
@@ -21,7 +25,7 @@ zh-HK:
         leap_format_short: 閏%{month_label}
         ym_format: ", %{heavenly_stem}%{earthly_branch}%{zodiac_animal}年%{leap_month_label}"
         month_labels:
-        -
+        - 
         - 正月
         - 二月
         - 三月
@@ -35,7 +39,7 @@ zh-HK:
         - 十一月
         - 十二月
         date_labels:
-        -
+        - 
         - 初一
         - 初二
         - 初三
@@ -175,7 +179,7 @@ zh-HK:
       hijri:
         ym_format: ", %{month_label} %{alt_year}"
         month_labels:
-        -
+        - 
         - Muharram
         - Safar
         - Rabiʻ I
@@ -191,7 +195,7 @@ zh-HK:
       bengali:
         ym_format: ", %{month_label} %{alt_year}"
         month_labels:
-        -
+        - 
         - Boishakh
         - Joishtho
         - Asharh
@@ -207,7 +211,7 @@ zh-HK:
       indian:
         ym_format: ", %{month_label} %{alt_year}"
         month_labels:
-        -
+        - 
         - Chaitra
         - Vaisakha
         - Jyaistha

--- a/lib/trmnl/i18n/locales/plugin_renders/es-ES.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/es-ES.yml
@@ -1,7 +1,7 @@
 ---
 es-ES:
   renders:
-    and_x_more_prefix: y
+    and_x_more_prefix: "y"
     and_x_more_suffix: más
     days_left_year:
       title: Días Restantes En Este Año

--- a/lib/trmnl/i18n/locales/plugin_renders/pl.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/pl.yml
@@ -84,7 +84,7 @@ pl:
         leap_format_short: LM%{alt_month}
         ym_format: ", %{leap_month_label} %{heavenly_stem} %{earthly_branch}"
         month_labels:
-        -
+        - 
         - M1
         - M2
         - M3
@@ -98,7 +98,7 @@ pl:
         - M11
         - M12
         date_labels:
-        -
+        - 
         - '1'
         - '2'
         - '3'
@@ -200,7 +200,7 @@ pl:
       hijri:
         ym_format: ", %{month_label} %{alt_year}"
         month_labels:
-        -
+        - 
         - Muharram
         - Safar
         - Rabiʻ I
@@ -216,7 +216,7 @@ pl:
       bengali:
         ym_format: ", %{month_label} %{alt_year}"
         month_labels:
-        -
+        - 
         - Boishakh
         - Joishtho
         - Asharh
@@ -232,7 +232,7 @@ pl:
       indian:
         ym_format: ", %{month_label} %{alt_year}"
         month_labels:
-        -
+        - 
         - Chaitra
         - Vaisakha
         - Jyaistha

--- a/lib/trmnl/i18n/locales/web_ui/pl.yml
+++ b/lib/trmnl/i18n/locales/web_ui/pl.yml
@@ -467,7 +467,7 @@ pl:
         leap_format_short: LM%{alt_month}
         ym_format: ", %{leap_month_label} %{heavenly_stem} %{earthly_branch}"
         month_labels:
-        -
+        - 
         - M1
         - M2
         - M3
@@ -481,7 +481,7 @@ pl:
         - M11
         - M12
         date_labels:
-        -
+        - 
         - '1'
         - '2'
         - '3'
@@ -583,7 +583,7 @@ pl:
       hijri:
         ym_format: ", %{month_label} %{alt_year}"
         month_labels:
-        -
+        - 
         - Muharram
         - Safar
         - Rabiʻ I
@@ -599,7 +599,7 @@ pl:
       bengali:
         ym_format: ", %{month_label} %{alt_year}"
         month_labels:
-        -
+        - 
         - Boishakh
         - Joishtho
         - Asharh
@@ -615,7 +615,7 @@ pl:
       indian:
         ym_format: ", %{month_label} %{alt_year}"
         month_labels:
-        -
+        - 
         - Chaitra
         - Vaisakha
         - Jyaistha


### PR DESCRIPTION
## Overview
Added 4 words to the dictionary that are common to multiple plugins but specifically used in the Trello Public Boards plugin. Created translations for top 6 languages (en, nl, de, it, fr, es-ES).
https://discord.com/channels/1281055965508141100/1284987869546549268/1385640379256274976

## Screenshots/Screencasts
![plugin-f39ea2](https://github.com/user-attachments/assets/7cace577-8e67-42cc-8ead-358ab4d684dc)



