### PR TITLE
Fix capitalization of the word playlist in en and en-GB

### DIFF
--- a/lib/trmnl/i18n/locales/web_ui/en-GB.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en-GB.yml
@@ -315,8 +315,8 @@ en-GB:
       add_a_group: Add a Group
       add_a_plugin: Add a Plugin
       add_first_device_cta: Start by __adding__ your first TRMNL device!
-      add_to_playlist: Add to Playlist
-      create_first_playlist_cta: Create your playlist after __connecting__ your first plugin!
+      add_to_playlist: Add to playlist
+      create_first_playlist_cta: Create your Playlist after __connecting__ your first plugin!
       custom: Custom
       device_default: Device default
       display_period_from: Display from
@@ -338,11 +338,11 @@ en-GB:
       hide_playlist: Hide this item
       show_playlist: Show this item
     create:
-      error: Failed to update playlist
+      error: Failed to update Playlist
       success: Playlist updated
     destroy:
       error: Error removing item from playlist
-      success: Plugin removed from Playlist
+      success: Plugin removed from playlist
     toggle_visibility:
       success: Playlist item %{change}
     duplicate:
@@ -350,7 +350,7 @@ en-GB:
     sort:
       success: Playlist order updated
     set_preferences:
-      success: Smart playlist preference updated
+      success: Smart Playlist preference updated
   plugins:
     index:
       title: Plugins
@@ -412,7 +412,7 @@ en-GB:
     active: Active
     copy_are_you_sure: Are you sure you want to copy this setting?
     delete_are_you_sure: Are you sure you want to delete this setting?
-    delete: This will completely remove the plugin's settings. To simply hide this plugin from your device, delete it from your Playlist instead.
+    delete: This will completely remove the plugin's settings. To simply hide this plugin from your device, delete it from your playlist instead.
     inactive: Inactive
     no_plugin_settings_found: No plugin settings found.
     not_supported: Not supported on current device
@@ -498,7 +498,7 @@ en-GB:
     update:
       success: Plugin configuration updated successfully
     add_to_playlist:
-      success: Plugin added to Playlist
+      success: Plugin added to playlist
   referral_code:
     create:
       request_received: Request received, check your inbox

--- a/lib/trmnl/i18n/locales/web_ui/en.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en.yml
@@ -315,8 +315,8 @@ en:
       add_a_group: Add a Group
       add_a_plugin: Add a Plugin
       add_first_device_cta: Start by __adding__ your first TRMNL device!
-      add_to_playlist: Add to Playlist
-      create_first_playlist_cta: Create your playlist after __connecting__ your first plugin!
+      add_to_playlist: Add to playlist
+      create_first_playlist_cta: Create your Playlist after __connecting__ your first plugin!
       custom: Custom
       device_default: Device default
       display_period_from: Display from
@@ -338,11 +338,11 @@ en:
       hide_playlist: Hide this item
       show_playlist: Show this item
     create:
-      error: Failed to update playlist
+      error: Failed to update Playlist
       success: Playlist updated
     destroy:
       error: Error removing item from playlist
-      success: Plugin removed from Playlist
+      success: Plugin removed from playlist
     toggle_visibility:
       success: Playlist item %{change}
     duplicate:
@@ -350,7 +350,7 @@ en:
     sort:
       success: Playlist order updated
     set_preferences:
-      success: Smart playlist preference updated
+      success: Smart Playlist preference updated
   plugins:
     index:
       title: Plugins
@@ -412,7 +412,7 @@ en:
     active: Active
     copy_are_you_sure: Are you sure you want to copy this setting?
     delete_are_you_sure: Are you sure you want to delete this setting?
-    delete: This will completely remove the plugin's settings. To simply hide this plugin from your device, delete it from your Playlist instead.
+    delete: This will completely remove the plugin's settings. To simply hide this plugin from your device, delete it from your playlist instead.
     inactive: Inactive
     no_plugin_settings_found: No plugin settings found.
     not_supported: Not supported on current device
@@ -498,7 +498,7 @@ en:
     update:
       success: Plugin configuration updated successfully
     add_to_playlist:
-      success: Plugin added to Playlist
+      success: Plugin added to playlist
   referral_code:
     create:
       request_received: Request received, check your inbox


### PR DESCRIPTION
## Overview
Relates to this: https://github.com/usetrmnl/trmnl-i18n/issues/166

Changed capitalization of playlist to conform to "rule of thumb: when the subject of the message is the Playlist architecture, capitalize. when the subject is e.g. an error, playlist can be lowercase or capitalized."
