### PR TITLE
Fix typo in dutch: "Vergerg" instead of "Verberg"

### DIFF
--- a/lib/trmnl/i18n/locales/web_ui/nl.yml
+++ b/lib/trmnl/i18n/locales/web_ui/nl.yml
@@ -364,7 +364,7 @@ nl:
       displayed_now: Nu getoond
       not_displayed_yet: Nog niet getoond
       remove_from_playlist: Verwijderen van afspeellijst
-      hide_playlist: Vergerg dit item
+      hide_playlist: Verberg dit item
       show_playlist: Toon dit item
     create:
       error: Bijwerken van afspeellijst is mislukt


### PR DESCRIPTION


## Overview
"Vergerg" instead of "Verberg"

## Screenshots/Screencasts


## Details
