### PR TITLE
Add Lithuanian translation

### DIFF
--- a/lib/trmnl/i18n/locales/custom_plugins/lt.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/lt.yml
@@ -198,7 +198,7 @@ lt:
       error_new_title: Naujų receptų nerasta.
       error_new_subtitle: Taip neturėtų nutikti.
       error_self_title: Jūs nepaskelbėte jokių receptų.
-      error_self_subtitle: Sužinokite, kaip paskelbti savo pirmąjį receptą čia: https://help.trmnl.com/en/articles/9510536-private-plugins
+      error_self_subtitle: "Sužinokite, kaip paskelbti savo pirmąjį receptą čia: https://help.trmnl.com/en/articles/9510536-private-plugins"
       error_author_id_title: 'Vartotojas #{$authorId} nepaskelbė jokių receptų.'
       error_author_id_subtitle: Nerasta jokių receptų, susietų su šiuo ID.
       error_recipe_ids_title: Nerasta jokio recepto ID.

--- a/lib/trmnl/i18n/locales/custom_plugins/lt.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/lt.yml
@@ -1,0 +1,209 @@
+---
+lt:
+  custom_plugins:
+    today: šiandien
+    tomorrow: rytoj
+    updated: Atnaujinta
+    activity: Veikla
+    done: Atlikta
+    due: Terminas
+    deutsche_bahn_departures:
+      departures: Išvykimai
+      time: Laikas
+      line: Linija
+      destination: Kryptis
+      platform: Peronas
+      delay: Vėlavimas
+      train: Traukinys
+      on_time: Laiku
+      cancelled: Atšauktas
+      minutes: min
+      refreshed: Atnaujinta
+    simple_calendar:
+      title: Kalendorius
+      ym_format: "%B %Y"
+      chinese_korean:
+        leap_format: Keliamasis %{month_label}
+        leap_format_short: KM%{alt_month}
+        ym_format: ", %{leap_month_label} %{heavenly_stem} %{earthly_branch}"
+        month_labels:
+        -
+        - M1
+        - M2
+        - M3
+        - M4
+        - M5
+        - M6
+        - M7
+        - M8
+        - M9
+        - M10
+        - M11
+        - M12
+        date_labels:
+        -
+        - '1'
+        - '2'
+        - '3'
+        - '4'
+        - '5'
+        - '6'
+        - '7'
+        - '8'
+        - '9'
+        - '10'
+        - '11'
+        - '12'
+        - '13'
+        - '14'
+        - '15'
+        - '16'
+        - '17'
+        - '18'
+        - '19'
+        - '20'
+        - '21'
+        - '22'
+        - '23'
+        - '24'
+        - '25'
+        - '26'
+        - '27'
+        - '28'
+        - '29'
+        - '30'
+        heavenly_stems:
+        - Medis
+        - Medis
+        - Ugnis
+        - Ugnis
+        - Žemė
+        - Žemė
+        - Metalas
+        - Metalas
+        - Vanduo
+        - Vanduo
+        earthly_branches:
+        - Žiurkė
+        - Jautis
+        - Tigras
+        - Triušis
+        - Drakonas
+        - Gyvatė
+        - Arklys
+        - Ožka
+        - Beždžionė
+        - Gaidys
+        - Šuo
+        - Kiaulė
+      japanese:
+        rokuyo_terms:
+        - 先勝
+        - 友引
+        - 先負
+        - 仏滅
+        - 大安
+        - 赤口
+        nengo:
+          reiwa: Reiwa
+        ym_format: "%B %Y (%{nengo} %{alt_year})"
+        year_1: '1'
+      hebrew:
+        ym_format: ", %{month_label} %{alt_year}"
+        month_labels:
+        - Nisanas
+        - Ijaras
+        - Sivanas
+        - Tamuzas
+        - Avas
+        - Elulas
+        - Tišrėjas
+        - Hešvanas
+        - Kislevas
+        - Tevetas
+        - Ševatas
+        - Adaras
+        - I Adaras
+        - II Adaras
+        month_labels_abbr:
+        - Nis
+        - Ija
+        - Siv
+        - Tam
+        - Av
+        - Elu
+        - Tiš
+        - Heš
+        - Kis
+        - Tev
+        - Šev
+        - Ada
+        - Ad1
+        - Ad2
+      hijri:
+        ym_format: ", %{month_label} %{alt_year}"
+        month_labels:
+        -
+        - Muharramas
+        - Safaras
+        - I Rabija
+        - II Rabija
+        - I Džumada
+        - II Džumada
+        - Radžabas
+        - Šabanas
+        - Ramadanas
+        - Šavalas
+        - Zu al-Kada
+        - Zu al-Hidža
+      bengali:
+        ym_format: ", %{month_label} %{alt_year}"
+        month_labels:
+        -
+        - Boišachas
+        - Džoišthas
+        - Ašarhas
+        - Srabonas
+        - Bhadras
+        - Ašvinas
+        - Kartika
+        - Ogrohajonas
+        - Poušas
+        - Maghas
+        - Falgunas
+        - Čoitras
+      indian:
+        ym_format: ", %{month_label} %{alt_year}"
+        month_labels:
+        -
+        - Čaitra
+        - Vaišacha
+        - Jjaištha
+        - Asadha
+        - Sravana
+        - Bhadra
+        - Asvina
+        - Kartika
+        - Agrahajana
+        - Pausa
+        - Magha
+        - Phalguna
+    public_recipe_stats:
+      connections: ".input {$value :number} .match $value zero {{Nėra prisijungimų}} one {{{$value :number} prisijungimas}} other {{{$value :number} prisijungimai}}"
+      forks: ".input {$value :number} .match $value zero {{Nėra atšakų}} one {{{$value :number} atšaka}} other {{{$value :number} atšakos}}"
+      installs: ".input {$value :number} .match $value zero {{Nėra įdiegimų}} one {{{$value :number} įdiegimas}} other {{{$value :number} įdiegimai}}"
+      and_more: ir dar {$value :number}
+      error_keyword_title: "„{$keyword}“ neatitiko jokių rezultatų."
+      error_keyword_subtitle: Pabandykite ieškoti ko nors kito.
+      error_new_title: Naujų receptų nerasta.
+      error_new_subtitle: Taip neturėtų nutikti.
+      error_self_title: Jūs nepaskelbėte jokių receptų.
+      error_self_subtitle: Sužinokite, kaip paskelbti savo pirmąjį receptą čia: https://help.trmnl.com/en/articles/9510536-private-plugins
+      error_author_id_title: 'Vartotojas #{$authorId} nepaskelbė jokių receptų.'
+      error_author_id_subtitle: Nerasta jokių receptų, susietų su šiuo ID.
+      error_recipe_ids_title: Nerasta jokio recepto ID.
+      error_recipe_ids_subtitle: Pridėkite recepto ID, kad pradėtumėte.
+    horizontal_world_clock:
+      name: Pasaulio laikrodis
+    language_learning_sentences:
+      from_to: "iš {$from :langName} į {$to :langNameList}"

--- a/lib/trmnl/i18n/locales/custom_plugins/lt.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/lt.yml
@@ -188,10 +188,10 @@ lt:
         - Pausa
         - Magha
         - Phalguna
-    public_recipe_stats:
-      connections: ".input {$value :number} .match $value zero {{Nėra prisijungimų}} one {{{$value :number} prisijungimas}} other {{{$value :number} prisijungimai}}"
-      forks: ".input {$value :number} .match $value zero {{Nėra atšakų}} one {{{$value :number} atšaka}} other {{{$value :number} atšakos}}"
-      installs: ".input {$value :number} .match $value zero {{Nėra įdiegimų}} one {{{$value :number} įdiegimas}} other {{{$value :number} įdiegimai}}"
+public_recipe_stats:
+      connections: '.input {$value :number} .match $value zero {{Nėra prisijungimų}} one {{{$value :number} prisijungimas}} other {{{$value :number} prisijungimai}}'
+      forks: '.input {$value :number} .match $value zero {{Nėra atšakų}} one {{{$value :number} atšaka}} other {{{$value :number} atšakos}}'
+      installs: '.input {$value :number} .match $value zero {{Nėra įdiegimų}} one {{{$value :number} įdiegimas}} other {{{$value :number} įdiegimai}}'
       and_more: ir dar {$value :number}
       error_keyword_title: "„{$keyword}“ neatitiko jokių rezultatų."
       error_keyword_subtitle: Pabandykite ieškoti ko nors kito.

--- a/lib/trmnl/i18n/locales/custom_plugins/lt.yml
+++ b/lib/trmnl/i18n/locales/custom_plugins/lt.yml
@@ -188,7 +188,7 @@ lt:
         - Pausa
         - Magha
         - Phalguna
-public_recipe_stats:
+    public_recipe_stats:
       connections: '.input {$value :number} .match $value zero {{Nėra prisijungimų}} one {{{$value :number} prisijungimas}} other {{{$value :number} prisijungimai}}'
       forks: '.input {$value :number} .match $value zero {{Nėra atšakų}} one {{{$value :number} atšaka}} other {{{$value :number} atšakos}}'
       installs: '.input {$value :number} .match $value zero {{Nėra įdiegimų}} one {{{$value :number} įdiegimas}} other {{{$value :number} įdiegimai}}'

--- a/lib/trmnl/i18n/locales/plugin_renders/lt.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/lt.yml
@@ -1,0 +1,280 @@
+---
+lt:
+  renders:
+    and_x_more_prefix: Ir dar
+    and_x_more_suffix: daugiau
+    days_left_year:
+      title: Dienų liko šiais metais
+      days_passed: Praėjo dienų
+      days_left: Liko dienų
+    lunar_calendar:
+      title: Mėnulio kalendorius
+      age: Mėnulio amžius
+      current_phase: Dabartinė fazė
+      illumination: Mėnulio apšviestumas
+      next_full_moon: Kita pilnatis
+      next_new_moon: Kita jaunatis
+      next_phase: Kita fazė
+      next_phase_short: Sekanti
+      moon_phases:
+        new_moon: Jaunatis
+        waxing_crescent: Jaunas mėnulis (priešpriešis)
+        first_quarter: Priešpilnis
+        waxing_gibbous: Isipūtęs mėnulis (prieš pilnatį)
+        full_moon: Pilnatis
+        waning_gibbous: Delčia (po pilnaties)
+        third_quarter: Delčia (paskutinis ketvirtis)
+        waning_crescent: Senas mėnulis
+    netatmo_weather_station:
+      title: Netatmo orai
+      title_short: Netatmo
+      indoor_temp: Vidaus temp.
+      indoor_temp_short: Viduje
+      indoor_humidity: Vidaus drėgmė
+      indoor_humidity_short: Vidaus drėgn.
+      outdoor_humidity: Lauko drėgmė
+      outdoor_humidity_short: Lauko drėgn.
+      co2: CO₂
+      co2_ppm: CO₂ ppm
+      pressure: Slėgis
+      noise: Triukšmas
+      min_max: Min/Maks
+      feels: Juntama
+      rain: Lietus
+      wind: Vėjas
+      gust: Gūsis
+      default_station_name: Netatmo stotelė
+      default_outdoor_module: Lauko temp.
+      default_indoor_module: Viduje
+      trends_title: "%{metric} tendencijos"
+      trends_title_short: Tendencijos
+      temperature_trends: Temperatūros tendencijos
+      temperature_trends_short: Temp. tendencijos
+      outdoor_now: Lauke dabar
+      indoor_now: Viduje dabar
+      now: Dabar
+      low_high_24h: 24 val. žemiausia / aukščiausia
+      average_24h: 24 val. vidurkis
+      outdoor: Lauke
+      indoor: Viduje
+      rain_gauge_not_connected: Lietaus matuoklis neprijungtas
+      wind_gauge_not_connected: Vėjo matuoklis neprijungtas
+      no_rain_gauge: Nėra lietaus matuoklio
+      no_wind_gauge: Nėra vėjo matuoklio
+      add_module_hint: Pridėkite papildomą %{module} modulį, kad matytumėte šiuos duomenis
+      range_24h: 24 val. diapazonas
+      errors:
+        missing_access_token: Trūksta prieigos rakto. Prašome iš naujo prijungti Netatmo paskyrą.
+        no_station_selected: Nepasirinkta meteorologinė stotelė. Pasirinkite stotelę nustatymuose.
+        connection_failed: Nepavyko prisijungti prie Netatmo stotelės. Patikrinkite interneto ryšį.
+        data_retrieval_failed: Nepavyko gauti orų duomenų. Bandykite vėliau.
+        session_expired: Sesija baigėsi. Nustatymuose iš naujo prijunkite Netatmo paskyrą.
+    parcel:
+      delivery_by: Pristatys iki
+      empty: Pristatymų nėra
+      errors:
+        api: Siuntų API klaida
+        http: HTTP klaida %{code}
+        internal: Vidinė klaida
+      filter_modes:
+        active:
+          one: Aktyvus pristatymas
+          other: Aktyvūs pristatymai
+        recent:
+          one: Nesenas pristatymas
+          other: Neseni pristatymai
+      status:
+        delivered: Pristatyta
+        delivery_exception: Pristatymo išimtis (trikdys)
+        expecting_pickup: Laukiama atsiėmimo
+        failed_delivery_attempt: Nesėkmingas bandymas pristatyti
+        frozen: Įšaldyta
+        in_transit: Pakeliui
+        information_received: Informacija gauta
+        not_found: Nerasta
+        out_for_delivery: Išduota kurjeriui
+        unknown: Nežinoma
+      today: Šiandien
+      tomorrow: Rytoj
+    weather:
+      title: Orai
+      temperature: Temperatūra
+      feels_like: Juntama kaip
+      humidity: Drėgmė
+      low: Žemiausia
+      high: Aukščiausia
+      uv: UV
+      right_now: Šiuo metu
+      today: Šiandien
+      tomorrow: Rytoj
+      low_high_short: Ž/A
+      uv_short: UV
+      max: Maks.
+      tempest:
+        conditions:
+          clear: Giedra
+          cloudy: Debesuota
+          foggy: Rūkas
+          partly_cloudy: Mažai debesuota
+          rain_likely: Tikėtinas lietus
+          rain_possible: Galimas lietus
+          snow: Sniegas
+          snow_possible: Galimas sniegas
+          thunderstorms_likely: Tikėtina perkūnija
+          thunderstorms_possible: Galima perkūnija
+          very_light_rain: Labai lengvas lietus
+          windy: Vėjuota
+          wintry_mix_likely: Tikėtina šlapdriba
+          wintry_mix_possible: Galima šlapdriba
+      weatherapi:
+        uv:
+          low: Žemas
+          moderate: Vidutinis
+          high: Aukštas
+          very_high: Labai aukštas
+          extreme: Ekstremalus
+        conditions:
+        - code: 1000
+          day: Saulėta
+          night: Giedra
+        - code: 1003
+          day: Mažai debesuota
+          night: Mažai debesuota
+        - code: 1006
+          day: Debesuota
+          night: Debesuota
+        - code: 1009
+          day: Apsiniaukę
+          night: Apsiniaukę
+        - code: 1030
+          day: Migla
+          night: Migla
+        - code: 1063
+          day: Lengvas lietus
+          night: Lengvas lietus
+        - code: 1066
+          day: Lengvas sniegas
+          night: Lengvas sniegas
+        - code: 1069
+          day: Šlapdriba
+          night: Šlapdriba
+        - code: 1072
+          day: Šalanti dulksna
+          night: Šalanti dulksna
+        - code: 1087
+          day: Perkūnija
+          night: Perkūnija
+        - code: 1114
+          day: Pūga
+          night: Pūga
+        - code: 1117
+          day: Stipri pūga
+          night: Stipri pūga
+        - code: 1135
+          day: Rūkas
+          night: Rūkas
+        - code: 1147
+          day: Šalantis rūkas
+          night: Šalantis rūkas
+        - code: 1150
+          day: Lengva dulksna
+          night: Lengva dulksna
+        - code: 1153
+          day: Dulksna
+          night: Dulksna
+        - code: 1168
+          day: Šalanti dulksna
+          night: Šalanti dulksna
+        - code: 1171
+          day: Stipri šalanti dulksna
+          night: Stipri šalanti dulksna
+        - code: 1180
+          day: Nedidelis lietus
+          night: Nedidelis lietus
+        - code: 1183
+          day: Lengvas lietus
+          night: Lengvas lietus
+        - code: 1186
+          day: Vidutinis lietus
+          night: Vidutinis lietus
+        - code: 1189
+          day: Lietus
+          night: Lietus
+        - code: 1192
+          day: Stiprus lietus
+          night: Stiprus lietus
+        - code: 1195
+          day: Labai stiprus lietus
+          night: Labai stiprus lietus
+        - code: 1198
+          day: Šalanti dulksna
+          night: Šalanti dulksna
+        - code: 1201
+          day: Šalantis lietus
+          night: Šalantis lietus
+        - code: 1204
+          day: Lengva šlapdriba
+          night: Lengva šlapdriba
+        - code: 1207
+          day: Šlapdriba
+          night: Šlapdriba
+        - code: 1210
+          day: Lengvas sniegas
+          night: Lengvas sniegas
+        - code: 1213
+          day: Nedidelis sniegas
+          night: Nedidelis sniegas
+        - code: 1216
+          day: Vidutinis sniegas
+          night: Vidutinis sniegas
+        - code: 1219
+          day: Sniegas
+          night: Sniegas
+        - code: 1222
+          day: Stiprus sniegas
+          night: Stiprus sniegas
+        - code: 1225
+          day: Labai stiprus sniegas
+          night: Labai stiprus sniegas
+        - code: 1237
+          day: Ledo kruša
+          night: Ledo kruša
+        - code: 1240
+          day: Lengvas liūtis
+          night: Lengvas liūtis
+        - code: 1243
+          day: Liūtis
+          night: Liūtis
+        - code: 1246
+          day: Labai stipri liūtis
+          night: Labai stipri liūtis
+        - code: 1249
+          day: Lengva šlapdriba
+          night: Lengva šlapdriba
+        - code: 1252
+          day: Šlapdriba
+          night: Šlapdriba
+        - code: 1255
+          day: Lengvas sniegas
+          night: Lengvas sniegas
+        - code: 1258
+          day: Sniegas (liūtis)
+          night: Sniegas (liūtis)
+        - code: 1261
+          day: Lengva kruša
+          night: Lengva kruša
+        - code: 1264
+          day: Kruša
+          night: Kruša
+        - code: 1273
+          day: Perkūnija ir lietus
+          night: Perkūnija ir lietus
+        - code: 1276
+          day: Perkūnija ir stiprus lietus
+          night: Perkūnija ir stiprus lietus
+        - code: 1279
+          day: Perkūnija ir nedidelis sniegas
+          night: Perkūnija ir nedidelis sniegas
+        - code: 1282
+          day: Perkūnija ir sniegas
+          night: Perkūnija ir sniegas

--- a/lib/trmnl/i18n/locales/web_ui/lt.yml
+++ b/lib/trmnl/i18n/locales/web_ui/lt.yml
@@ -1,0 +1,637 @@
+---
+lt:
+  locale_name: Lietuvių
+  about: Apie
+  add: Pridėti
+  add_new: Pridėti naują
+  already_have_account: Jau turiu paskyrą
+  are_you_sure: Ar esate tikri?
+  back: Atgal
+  back_to_all_blog_posts: Atgal į visus įrašus
+  blog: Tinklaraštis
+  brand: Prekių ženklas
+  buy_now: Pirkti dabar
+  cancel: Atšaukti
+  change_password: Pakeisti slaptažodį
+  charge_level: Įkrovos lygis
+  charged: įkrauta
+  charging: Įkraunama
+  claim_plus_trial: Atsiimti 6 mėnesius nemokamai
+  close: Uždaryti
+  confirm_change_password: Pakeisti mano slaptažodį
+  confirm_password: Patvirtinti naują slaptažodį
+  copy: Kopijuoti
+  copied_to_clipboard: Nukopijuota!
+  copy_to_clipboard: Kopijuoti į iškarpinę
+  created: Sukurta
+  create_an_account: Sukurti paskyrą
+  current_device: Dabartinis įrenginys
+  days: dienos
+  delete: Ištrinti
+  developers: Kūrėjams
+  developer_edition_required: Norint įjungti šią funkciją, reikalinga kūrėjo versija.
+  device_id: Įrenginio ID
+  device: Įrenginys
+  edit: Redaguoti
+  email_address: El. pašto adresas
+  export: Eksportuoti
+  fetching: Gaunama
+  first_name: Vardas
+  forgot_password: Pamiršau slaptažodį
+  forgot_password_title: Ir vėl viskas iš naujo
+  friendly_id: Atpažįstamas ID (Friendly ID)
+  get_started: Pradedėkime!
+  hidden: paslėptas
+  identify: Identifikuoti
+  import: Importuoti
+  import_new: Importuoti naują
+  integrations: Integracijos
+  keep_me_signed_in: Likti prisijungusiam
+  knowledge_base: Žinių bazė
+  last_name: Pavardė
+  learn_more: Sužinoti daugiau
+  loading: Įkeliama
+  login: Prisijungti
+  log_out: Atsijungti
+  manage: Tvarkyti
+  minimum_characters: simbolių minimumas
+  mins: min.
+  my_playlist: Mano grojaraštis
+  new_password: Naujas slaptažodis
+  password: Slaptažodis
+  please_wait: Prašome palaukti...
+  plugin_not_found: Įskiepis nerastas
+  preview: Peržiūra
+  privacy: Privatumas
+  refresh_rate: Atnaujinimo dažnis
+  refresh_rates_hint: Sužinokite, kaip veikia atnaujinimo dažniai, __čia__.
+  reset_password: Atstatyti mano slaptažodį
+  reset_to_defaults: Atstatyti numatytuosius nustatymus
+  required: Privaloma
+  save: Išsaugoti
+  shown: rodomas
+  section: Sekcija
+  settings: Nustatymai
+  sign_in: Prisijungti
+  sign_up: Užsiregistruoti
+  something_went_wrong: Kažkas nepavyko
+  status: Būsena
+  subscribe: Prenumeruoti
+  help_center: Pagalba
+  terms: Sąlygos
+  update: Atnaujinti
+  view: Peržiūrėti
+  collaboration_request: Norite bendradarbiauti?
+  collaboration_request_hint: Partnerystės, grupiniai pardavimai, specialūs projektai – jūsų pasirinkimas.
+  collaboration_request_cta: Pasikalbėkime
+  welcome: Sveiki
+  time:
+    formats:
+      shorter: "%-I:%M %p"
+    start_of_week: 1
+  datetime:
+    relative:
+      past: "prieš %{time}"
+      future: "po %{time}"
+      distance_in_words:
+        half_a_minute: "pusė minutės"
+        less_than_x_seconds:
+          one: "mažiau nei %{count} sekundė"
+          other: "mažiau nei %{count} sekundės"
+        less_than_x_minutes:
+          one: "mažiau nei minutė"
+          other: "mažiau nei %{count} minutės"
+        x_seconds:
+          one: "%{count} sekundė"
+          other: "%{count} sekundės"
+        x_minutes:
+          one: "%{count} minutė"
+          other: "%{count} minutės"
+        about_x_hours:
+          one: "maždaug %{count} valanda"
+          other: "maždaug %{count} valandos"
+        x_days:
+          one: "%{count} diena"
+          other: "%{count} dienos"
+        about_x_months:
+          one: "maždaug %{count} mėnesis"
+          other: "maždaug %{count} mėnesiai"
+        x_months:
+          one: "%{count} mėnesis"
+          other: "%{count} mėnesiai"
+        about_x_years:
+          one: "maždaug %{count} metai"
+          other: "maždaug %{count} metai"
+        over_x_years:
+          one: "virš %{count} metų"
+          other: "virš %{count} metų"
+        almost_x_years:
+          one: "beveik %{count} metai"
+          other: "beveik %{count} metai"
+  account:
+    index:
+      title: Paskyra
+      tagline: Tvarkykite savo paskyros nustatymus
+      api_key_confirm: Ar tikrai norite sugeneruoti naują API raktą? Senasis raktas bus anuliuotas.
+      api_key_hint: Žiūrėkite __dokumentaciją__, kad sužinotumėte, kaip sukonfigūruoti vietinę aplinką.
+      api_key_label: Kredencialai, skirti autentifikuoti vietinius kūrimo įrankius
+      api_key_not_generated: "(kol kas nėra)"
+      api_key_reset: Sugeneruoti iš naujo
+      api_key: Vartotojo API raktas
+      beta_features: Beta funkcijos
+      beta_features_hint: Išbandykite naujas funkcijas čia. Parinktys bet kada gali išnykti.
+      discord_community: Discord bendruomenė
+      discord_username: Koks jūsų Discord vartotojo vardas?
+      discord_username_hint: Gali būti naudojamas pagalbai, autorystei nurodyti paskelbtuose receptuose ir kt.
+      email_address: El. pašto adresas
+      refer_and_earn: Rekomenduokite ir uždirbkite
+      refer_and_earn_hint: Padovanokite TRMNL su asmeniniu kuponu. Uždirbkite už kiekvieną panaudojimą, mokama kas mėnesį.
+      refer_and_earn_redemptions: Panaudojimai
+      refer_and_earn_request_code: Užklausti kodą
+      device_invoice: Įrenginio sąskaita-faktūra
+      device_invoice_label: Atsisiųskite komercinius dokumentus savo buhalteriui arba (keistai) PDF kolekcijai.
+      device_invoice_hint: Ją rasite siuntos sekimo puslapyje arba pranešime el. paštu apie išsiuntimą.
+      email_address_hint: Naudojama prisijungimui prie TRMNL ir sistemos pranešimams gauti.
+      first_name_hint: Mes naudojame jūsų vardą, kad TRMNL sąsaja būtų jaukesnė.
+      last_name_hint: Mes naudojame jūsų pavardę, kad TRMNL sąsaja būtų jaukesnė.
+      password_hint: Naudojamas jūsų TRMNL paskyros apsaugai.
+      enable_2fa: Įjungti 2FA?
+      enable_2fa_hint: __Spustelėkite čia__, kad įjungtumėte OTP.
+      disable_2fa: Išjungti 2FA
+      disable_2fa_hint: Norėdami išjungti šią funkciją, aukščiau pateikite galiojantį OTP ir dabartinį slaptažodį.
+      plus_subscription: TRMNL+ prenumerata
+      plus_subscription_trial_until: Jūs naudojatės nemokama bandomąja versija iki %{plus_trial_end_at}.
+      plus_subscription_hint: Atrakinkite greitesnį atnaujinimo dažnį ir didesnius limitus. __Sužinokite daugiau__.
+      plus_subscription_modify: Norite atnaujinti mokėjimo būdą arba atšaukti?
+      session: Sesija
+      session_hint: Esate prisijungęs kaip %{user}
+      show_title_bar: Rodyti pavadinimo juostą
+      show_title_bar_hint: Jei išjungta, vietiniai ir trečiųjų šalių įskiepiai bus minimalistiškesni.
+      theme_hint: Suasmeninkite TRMNL sąsają nustatydami temą arba sinchronizuodami ją su savo įrenginiu.
+      time_zone: Laiko juosta
+      time_zone_hint: Nustato atnaujinimo dažnį ir įrenginio miego laiką.
+      locale: Kalba (Locale)
+      locale_hint: Kokiai kalbai ir lokalizacijai teikiate pirmenybę? __Eikite čia__.
+    update:
+      success: Profilis sėkmingai atnaujintas
+    reset_api_key:
+      success: API raktas sėkmingai sugeneruotas iš naujo
+  dashboard:
+    index:
+      title: Skydelis
+      last_7_days: Paskutinės 7 dienos
+      last_30_days: Paskutinės 30 dienų
+      last_90_days: Paskutinės 90 dienų
+      today: Šiandien
+      yesterday: Vakar
+    health:
+      bad: Įskiepiai patiria problemų
+      good: Įskiepiai veikia puikiai
+      next_steps: Mes jus informuosime, jei kas nors pasikeis
+    news:
+      title: Naujienos
+      cta: Žiūrėti viską
+    playlist_items:
+      title: Grojaraštis
+      cta: Redaguoti grojaraštį
+      pieces_of_content_displayed: Rodomo turinio kiekis
+    plugins:
+      title: Įskiepiai
+      cta: Eiti į įskiepius
+      connected: Prijungta
+      new_and_popular: Nauji ir populiarūs
+    shop:
+      title: Parduotuvė
+      need_another: Reikia dar vieno TRMNL?
+    time_saved:
+      title: Sutaupytas laikas
+      cta: Skaityti apie
+    welcome_message:
+      morning_salutation: Labas rytas
+      afternoon_salutation: Laba diena
+      evening_salutation: Labas vakaras
+  devices:
+    edit:
+      accepts_beta_firmware: Ankstyvoji programinės įrangos versija
+      accepts_beta_firmware_hint: Įjunkite, kad gautumėte naujausius įrenginio programinės įrangos patobulinimus anksčiau už kitus.
+      back_to_devices: Atgal į įrenginius
+      battery_and_sleep: Baterija ir miegas
+      battery_consumption: Baterijos suvartojimas
+      battery_consumption_hint: Taupykite energiją ir mėgaukitės ilgesniu baterijos veikimo laiku įjungdami miego režimą.
+      battery_learn_more: Sužinokite daugiau apie baterijos įkrovimą __čia__.
+      battery_refresh: Atnaujinti
+      developer_perks: Privilegijos kūrėjams
+      developer_perks_hint: Pasirinktinių įskiepių kūrimas, redaguojamas MAC adresas (tik BYOD), ankstyvosios programinės įrangos versijos ir API prieiga.
+      device_credentials: Įrenginio kredencialai
+      device_credentials_hint: Sužinokite, ką galite daryti su šiais kredencialais __čia__.
+      device_name: Įrenginio pavadinimas
+      device_name_hint: Mes naudojame tai, kad TRMNL sąsaja būtų jaukesnė.
+      device_model: Įrenginio modelis
+      device_model_hint: Jūsų aparatinės įrangos modelis
+      device_model_switch_warning: Tai pavojingas veiksmas, sužinokite daugiau __čia__.
+      device_info: Įrenginio informacija
+      current_firmware: Dabartinė programinė įranga
+      last_ping: Paskutinis signalas (ping)
+      unknown: Nežinoma
+      never: Niekada
+      display_calibration: Ekrano kalibravimas
+      display_calibration_hint: Tiksliai sureguliuokite atvaizdavimą savo ekranui. Palikite tuščią, kad naudotumėte numatytuosius modelio nustatymus.
+      display_calibration_pixel_ratio: Pikselių santykis
+      display_calibration_pixel_ratio_hint: 'Vaizdo mastelis (0.5–3.0). Numatytasis:'
+      display_calibration_ui_scale: Sąsajos mastelis (UI Scale)
+      display_calibration_ui_scale_hint: 'Teksto ir elementų dydžiai (0.5–2.0). Numatytasis:'
+      edit_device: Redaguoti įrenginį
+      firmware: Programinė įranga
+      firmware_updates_enabled: Atnaujinimai įjungti
+      firmware_updates_disabled: Atnaujinimai išjungti
+      guest_mode: Svečio režimas
+      guest_mode_hint: Pasirinkite, ką rodyti (ir kiek laiko), kai įjungtas svečio režimas.
+      guest_mode_item_placeholder: Pasirinkite elementą
+      guest_mode_duration_placeholder: Pasirinkite trukmę
+      identify: Identifikuoti
+      identify_device: Identifikuoti įrenginį
+      identify_device_hint: Spustelėkite žemiau esantį mygtuką, kad šio įrenginio ekrane būtų sugeneruotas vaizdas, padedantis jį atpažinti.
+      logs: Žurnalai (Logs)
+      logs_hint: Derinkite savo įrenginį ir įskiepius naudodami tiesioginį klaidų žurnalų srautą.
+      low_battery_email_notification: Pranešimas el. paštu apie senkančią bateriją
+      low_battery_email_notification_hint: Gaukite pranešimą el. paštu, kai jūsų įrenginio baterija senka.
+      mirror: Veidrodinis atspindys
+      mirror_device: Atspindėti kitą įrenginį
+      mirror_device_hint: Pateikite (bendrinamą) įrenginio ID, kad atspindėtumėte jo grojaraštį. Jūsų grojaraštis vis tiek bus rodomas.
+      mirror_disabled: Atspindėjimas išjungtas
+      mirror_enabled: Atspindima
+      mirror_stop: Atjungti atspindėjimą
+      mirror_sync: Sinchronizuoti ekranus
+      ota_enabled: OTA atnaujinimai įjungti
+      ota_enabled_hint: Automatiškai įdiegti naują programinę įrangą. Išjunkite, kad naudotumėte savo programinę įrangą.
+      ota_byod_not_supported: OTA nepalaikoma BYOD įrenginiuose. Įrašykite suderinamą versiją tiesiogiai iš trmnl.com/flash
+      maximum_compatibility: Įjungti maksimalų suderinamumą
+      maximum_compatibility_hint: Išsprendžia ekrano problemas, kurias sukelia tam tikros e-ink tvarkyklės. Išjungia greitąjį atnaujinimą. Reikalinga programinė įranga 1.6.0+.
+      palette: Spalvų paletė
+      palette_hint: Pasirinkite spalvų rinkinį, kuris bus naudojamas generuojant šio įrenginio ekranus. Didesnė paletė atrodo gražiau, tačiau mažesnė paletė e-ink ekrane piešiama greičiau. Atskiri grojaraščio elementai gali perrašyti šį nustatymą.
+      sleep_mode: Miego režimas
+      sleep_mode_hint: Sureguliuokite atnaujinimo dažnį, kad optimizuotumėte dėmesio sutelkimą ir baterijos veikimo laiką.
+      sleep_screen: Miego ekranas
+      sleep_screen_tooltip: Įjunkite miego režimą, kad galėtumėte naudotis šia funkcija
+      sleep_screen_hint: Miego režimo valandomis rodyti miego ekraną.
+      special_function: Speciali funkcija
+      special_function_hint: Nustatykite pasirinktinę funkciją mygtukui, esančiam jūsų įrenginio nugarėlėje.
+      special_function_learn_more: Sužinokite daugiau apie specialias funkcijas __čia__.
+      temperature_profile: Temperatūros profilis
+      temperature_profile_hint: Nekeiskite, nebent buvo taip nurodyta. Skirta ekranams su išblukusiais vaizdais.
+      touchbar_mode: Jutiklinės juostos režimas
+      touchbar_mode_hint: Į kokio tipo gestus turėtų reaguoti jūsų įrenginys?
+      tidbyt_credentials: Tidbyt kredencialai
+      tidbyt_credentials_hint: Įveskite savo Tidbyt įrenginio API kredencialus iš Tidbyt programėlės (skiltyje Settings → Developer → Get API Key).
+      tidbyt_credentials_invalid: Tidbyt API kredencialai negalioja. Patikrinkite ir bandykite dar kartą.
+      tidbyt_device_id: Įrenginio ID
+      tidbyt_device_api_key: API raktas
+      unlink: Atjungti
+      unlink_confirm: Ar esate tikri? Tęskite tik tuo atveju, jei atiduodate šį įrenginį kitam asmeniui arba pereinate prie BYOS. Atjungimas ištrina visus įskiepių nustatymus ir grojaraščio elementus. Jei sprendžiate problemas, susisiekite su pagalba adresu help.trmnl.com.
+      unlink_device: Atjungti įrenginį
+      unlink_device_hint: Atjungus TRMNL įrenginį, jį saugu perparduoti arba atiduoti kitam asmeniui.
+      unlink_device_learn_more: Sekite pilną gidą __čia__.
+      visibility: Matomumas
+      visibility_hint: Padarykite savo TRMNL įrenginį atspindimą pakeisdami žemiau esančius nustatymus.
+      your_device: Jūsų TRMNL
+      upgrade_og:
+        title: Galimas atnaujinimas į 2-bitų ekraną
+        sub_title: Jūsų įrenginį galima atnaujinti, kad jis palaikytų patobulintą pilkų atspalvių ekraną su 4 spalvų lygiais vietoj 2.
+        warning_1: Suprantu, kad šis atnaujinimas yra <strong>negrįžtamas</strong> ir jo negalima atšaukti.
+        warning_2: Suprantu, kad tai yra <strong>pavojingas</strong> veiksmas ir gali sugadinti mano įrenginį.
+        cta: Atnaujinti į TRMNL OG (2-bit)
+    index:
+      title: Įrenginiai
+      tagline: Jūsų TRMNL įrenginiai
+      add_device_modal_title: Pridėti naują įrenginį
+      add_first_device: Pradėkite pridėdami savo pirmąjį įrenginį!
+    new:
+      title: Pridėti naują įrenginį
+      description: Įveskite savo Friendly ID, kad pridėtumėte naują įrenginį prie savo paskyros.
+      add_device: Pridėti naują įrenginį
+    associate:
+      error: Klaida susiejant įrenginį
+      success: Įrenginys sėkmingai susietas
+    dissociate:
+      error: Klaida atjungiant įrenginį
+      success: Įrenginys sėkmingai atjungtas
+    external_credentials:
+      error: Neteisingi įrenginio kredencialai
+      success: Įrenginio kredencialai sėkmingai atnaujinti
+    identify:
+      error: Klaida atnaujinant įrenginį
+      success: Užklaustas įrenginio identifikavimas
+    mirror:
+      error: Klaida atspindint įrenginį
+      error_not_shared: Pateiktas įrenginio ID nėra bendrinamas
+      error_oneself: Negalima atspindėti paties savęs
+      success: Įrenginys %{friendly_id} sėkmingai atspindėtas
+      success_removed: Atspindėjimas pašalintas
+    switch:
+      error: Klaida perjungiant įrenginį
+      success: Įrenginys sėkmingai perjungtas
+    update:
+      error: Klaida atnaujinant įrenginį
+      success: "%{device} įrenginio nustatymai sėkmingai atnaujinti"
+  invoices:
+    rate_limit: Per daug bandymų, palaukite ir bandykite dar kartą
+    invoice_not_found: Sąskaita-faktūra nerasta
+  logs:
+    index:
+      title: Žurnalai
+      all: Visi
+      bulk_destroy: Masinis trynimas
+      dump: Išrašas (Dump)
+      id: ID
+      private_plugins: Privatūs įskiepiai
+      source: Šaltinis
+      time: Laikas
+  markups:
+    console_logs:
+      js_logs: JS Žurnalai
+    form:
+      back_to_plugin_settings: Atgal į įskiepio nustatymus
+      design_system: Pasinaudokite mūsų vietine dizaino sistema
+      design_system_docs: Dizaino sistemos dokumentacija
+      dirty_confirm: Turite neišsaugotų pakeitimų. Ar tikrai norite išeiti iš šio puslapio?
+      edit_markup: Redaguoti žymėjimą
+      edit_markup_for_plugin: Redaguoti %{plugin_setting_name} žymėjimą
+      edit_markup_please_save_first: Prieš redaguodami žymėjimą, išsaugokite
+      edit_markup_without_preview: Redaguoti žymėjimą (be peržiūros)
+      error_rendering_markup: Klaida atvaizduojant žymėjimą
+      fix_indentation: Sutvarkyti įtraukas
+      go_to_preview: Eiti į peržiūrą
+      live_preview: Tiesioginė peržiūra
+      no_changes_to_save: Nėra pakeitimų, kuriuos reikėtų išsaugoti
+      pop_out_preview: Iškelti peržiūrą į atskirą langą
+      quickstart_examples: Greito starto pavyzdžiai
+      quickstart_example_applied: Pritaikyta!
+      quickstart_use_this_example: Naudoti šį pavyzdį
+      revert: Sugrąžinti
+      revert_confirm: Ar tikrai norite sugrąžinti? Visi neišsaugoti pakeitimai bus prarasti.
+      save_changes: Išsaugoti pakeitimus (⌘﹢S)
+      separate_preview: Peržiūra atidaryta atskirame lange
+    merge_variables:
+      your_variables: Jūsų kintamieji
+    no_merge_variables:
+      force_refresh: Jei pateikėte kintamuosius, bet jie neaptinkami, pabandykite __priverstinį atnaujinimą__.
+      no_variables_detected: Kintamųjų neaptikta.
+  mfa:
+    disable_otp:
+      success: 2FA išjungta
+      invalid_otp: Neteisingas OTP
+      invalid_password: Neteisingas slaptažodis
+      invalid_otp_and_password: Neteisingas OTP ir slaptažodis
+    enable_otp:
+      input_otp: Įveskite OTP
+      submit: Patvirtinti ir įjungti
+      already_enabled: 2FA jau įjungta
+    enable_otp_verify:
+      success: 2FA įjungta
+      error: Neteisingas OTP kodas
+    verify_otp:
+      verify: Patvirtinti
+      reset: Atstatyti MFA
+      reset_instructions: Spustelėkite mygtuką, esantį jūsų TRMNL nugarėlėje, kad sugeneruotumėte atstatymo kodą
+      success: 2FA sėkminga
+      error: Neteisingas OTP kodas
+  playlist_items:
+    index:
+      title: Grojaraštis
+      tagline: Pasirinkite, kas rodoma
+      add_a_group: Pridėti grupę
+      add_a_plugin: Pridėti įskiepį
+      add_first_device_cta: Pradėkite __pridėdami__ savo pirmąjį TRMNL įrenginį!
+      add_to_playlist: Pridėti į grojaraštį
+      create_first_playlist_cta: Sukurkite savo grojaraštį __prijungę__ savo pirmąjį įskiepį!
+      custom: Pasirinktinis
+      device_default: Įrenginio numatytasis
+      display_period_from: Rodyti nuo
+      display_period_to: iki
+      display_period_validation: Pradžios laikas turi būti ankstesnis už pabaigos laiką. Sukurkite kitą grupę, kad apimtumėte nakties valandas.
+      every: Kas
+      never_skip: Niekada nepraleisti ekranų
+      smart_playlist: Išmanusis grojaraštis
+      smart_playlist_hint: Automatiškai praleisti ekranus, kurių turinys kurį laiką nesikeitė.
+      skip_after:
+        one: Praleisti pasenusius ekranus po 1 dienos
+        other: Praleisti pasenusius ekranus po %{count} dienų
+    playlist_item:
+      adjust_schedule: Koreguoti tvarkaraštį
+      delete: Ar tikrai norite pašalinti šį elementą? Įskiepis liks prijungtas, tik nebus rodomas jūsų įrenginyje.
+      displayed_now: Rodoma dabar
+      not_displayed_yet: Dar nerodoma
+      remove_from_playlist: Pašalinti iš grojaraščio
+      hide_playlist: Paslėpti šį elementą
+      show_playlist: Rodyti šį elementą
+      duplicate: Dubliuoti
+      duplicate_confirm: Tai sukurs šio elemento kopiją ir pridės ją prie jūsų grojaraščio apačios. Tęsti?
+      color_palette: Spalvų paletė
+      device_default: Įrenginio numatytasis (%{name})
+      palette_unavailable: Galima tik įrenginiams su keliomis spalvų paletėmis
+      refresh_rate_disabled:
+        default: Šio įskiepio atnaujinimo dažnio negalima konfigūruoti.
+        external: Šis įskiepis nuskaito duomenis realiuoju laiku, todėl atnaujinimo dažnio nustatymai netaikomi.
+        global: Šis įskiepis atnaujinamas visoje platformoje pagal fiksuotą tvarkaraštį.
+        mashup: Mišinys (mashup) bus atnaujinamas taip dažnai, kaip jo greičiausias įskiepis.
+        readonly: Šis įskiepis turi fiksuotą atnaujinimo dažnį, kurio negalima konfigūruoti.
+    create:
+      error: Nepavyko atnaujinti grojaraščio
+      success: Grojaraštis atnaujintas
+    destroy:
+      error: Klaida šalinant elementą iš grojaraščio
+      success: Įskiepis pašalintas iš grojaraščio
+    toggle_visibility:
+      success: Grojaraščio elemento %{change}
+    duplicate:
+      success: Elementas dubliuotas
+    sort:
+      success: Grojaraščio tvarka atnaujinta
+    set_preferences:
+      success: Išmaniojo grojaraščio nustatymai atnaujinti
+    update:
+      success: Grojaraščio tvarka atnaujinta
+  plugins:
+    index:
+      title: Įskiepiai
+      tagline: Ką įkelsite į savo TRMNL?
+      available: Prieinami
+      connected: Prijungti
+      recipes: Receptai
+      recipes_hint: Bendruomenės narių privatūs įskiepiai, kuriuos galima įdiegti 1 spustelėjimu. __Sužinokite daugiau__.
+    search:
+      placeholder: Ieškoti įskiepių
+    my:
+      index:
+        title: Mano įskiepiai
+        tagline: Kurkite įskiepius viešajai rinkai
+      card:
+        connections: prisijungimai
+        install: Įdiegti
+        review_are_you_sure: Ar esate tikri? TRMNL komanda jį išbandys ir el. paštu atsiųs jums visus klausimus.
+        submit_for_review: Pateikti peržiūrai
+    new:
+      title: Sukurti naują įskiepį
+      tagline: Kiti vartotojai galės įsidiegti jūsų įskiepį.
+      name: Pavadinimas
+      category: Kategorija
+      category_hint: Laikykite nuspaudę cmd arba ctrl, kad pasirinktumėte iki 3
+      refresh_every: Palaikomas atnaujinimo intervalas
+      refresh_every_hint: Greičiausias atnaujinimo intervalas, kurį gali palaikyti jūsų įskiepis.
+      description: Aprašymas
+      description_hint: Maksimaliai 50 simbolių
+      icon: Ikona
+      icon_hint: Rekomenduojama 512x512px
+      installation_url: Įdiegimo URL
+      installation_url_hint: Sužinokite daugiau apie įdiegimo eigą __čia__.
+      installation_success_webhook_url: Įdiegimo sėkmės Webhook URL
+      knowledge_base_url: Žinių bazės URL
+      management_url: Įskiepio valdymo URL
+      management_url_hint: Sužinokite daugiau apie valdymo eigą __čia__.
+      markup_url: Įskiepio žymėjimo URL
+      markup_url_hint: Sužinokite daugiau apie ekrano generavimą __čia__.
+      no_screen_padding: Be ekrano paraščių
+      no_screen_padding_hint: Pašalina išorines paraštes viso ekrano režimu.
+      uninstallation_webhook_url: Išdiegimo Webhook URL
+    edit:
+      title: Redaguoti įskiepį
+      tagline: Atnaujinkite savo įskiepio informaciją.
+      name: Pavadinimas
+      description: Aprašymas
+  plugin_recipes:
+    connected: Receptas prijungtas
+    connections:
+      one: Prisijungimas
+      other: Prisijungimai
+    forks:
+      one: Atšaka (Fork)
+      other: Atšakos (Forks)
+    forked: Receptas atšakotas
+    new:
+      error: Receptas nerastas
+  plugin_settings:
+    active: Aktyvus
+    copy_are_you_sure: Ar tikrai norite nukopijuoti šį nustatymą?
+    delete_are_you_sure: Ar tikrai norite ištrinti šį nustatymą?
+    delete: Tai visiškai pašalins įskiepio nustatymus. Norėdami tiesiog paslėpti šį įskiepį savo įrenginyje, ištrinkite jį iš savo grojaraščio.
+    inactive: Neaktyvus
+    no_plugin_settings_found: Įskiepio nustatymų nerasta.
+    not_supported: Nepalaikoma dabartiniame įrenginyje
+    refreshing_now_please_wait: Dabar atnaujinama, perkraukite šį puslapį po kelių sekundžių.
+    reset_credentials: "%{plugin_name} paskyra sėkmingai atstatyta"
+    form:
+      active_hint: Rodyti arba paslėpti šią įskiepio instanciją savo įrenginyje
+      advanced_settings: Išplėstiniai nustatymai
+      back_to_playlist: Atgal į grojaraštį
+      back_to_plugin: Atgal į %{plugin}
+      back_to_plugins: Atgal į įskiepius
+      connect_with: Prisijungti su %{plugin}
+      debug_logs: Derinimo žurnalai
+      debug_logs_click_here: Spustelėkite čia
+      debug_logs_click_here_hint: norėdami įjungti derinimo žurnalus šiai įskiepio instancijai.
+      debug_logs_enabled: Derinimo žurnalai įjungti %{hours} valandoms.
+      debug_logs_enabled_link: Peržiūrėti žurnalus
+      disconnect_account: Atjungti paskyrą
+      manage_plugin: Konfigūruoti %{plugin}
+      force_refresh: Priverstinis atnaujinimas
+      force_refresh_hint: Ši funkcija skirta tik testavimui – prašome ja nepiktnaudžiauti.
+      force_refresh_click_here: Spustelėkite čia
+      force_refresh_click_here_hint: kad iškart sugeneruotumėte naują ekraną
+      force_refresh_not_possible: Šio įskiepio negalima atnaujinti priverstinai, nes TRMNL serveris neatlieka vaizdo apdorojimo. Sužinokite, kaip išbandyti savo instanciją __čia__.
+      learn_more: Sužinokite apie šį įskiepį mūsų žinių bazėje
+      learn_more_fork: Šis įskiepis buvo atšakotas iš recepto.
+      learn_more_fork_original: Žiūrėti originalą
+      learn_more_native_long: Šis įskiepis yra vietinis ir jį prižiūri TRMNL.
+      learn_more_native_short: Šį įskiepį prižiūri TRMNL.
+      learn_more_recipe_author: Reikia pagalbos? Susisiekite su %{recipe_author} per Discord.
+      learn_more_recipe_long: Šis įskiepis yra bendruomenės receptas ir jo neprižiūri TRMNL.
+      learn_more_recipe_short: 'Pastaba: šis įskiepis yra receptas.'
+      learn_more_third_party_long: Šis įskiepis yra trečiosios šalies ir jo neprižiūri TRMNL.
+      learn_more_third_party_short: 'Pastaba: šis įskiepis yra sukurtas trečiosios šalies.'
+      linked_account: Susieta paskyra
+      linked_account_success: Sėkmingai susieta su %{plugin_name}
+      link_oauth: Susieti paskyrą
+      link_oauth_hint: Prieš tęsdami, atlikite saugų autorizavimo procesą, kurį pateikia %{plugin}
+      mirrored: Atspindėta
+      multiple_instances_hint: Šis įskiepis palaiko kelias instancijas.
+      name: Pavadinimas
+      name_hint: Suteikite jam pavadinimą, kad būtų lengva rasti
+      parse: Analizuoti (Parse)
+      parse_save_first: Analizuoti (pirmiausia išsaugokite įskiepį)
+      parsed: Išanalizuota
+      plugin_uuid: Įskiepio UUID
+      plugin_uuid_hint: Naudokite tai Webhook API užklausoms atlikti.
+      preview: Peržiūra – jūsų įrenginys rodys tikrus duomenis
+      recipe_cta_heading_published: Šis įskiepis yra viešas
+      recipe_cta_heading_unlisted: Šis įskiepis yra neįtrauktas į sąrašus
+      recipe_cta_heading_in_review: Įskiepis peržiūrimas
+      recipe_cta_heading_not_published: Paskelbti įskiepį?
+      recipe_cta_body_published: Pakeitimai atsispindės esamuose diegimuose ir būsimuose diegimuose / atšakose.
+      recipe_cta_body_in_review: Šis įskiepis buvo pateiktas mūsų komandai. Palaukite.
+      recipe_cta_body_not_published: Pateikite šį įskiepį, kad kiti galėtų jį įsidiegti. __Sužinokite daugiau__.
+      recipe_cta_confirm: Ar esate tikri? Mūsų komanda peržiūrės ir susisieks su jumis per porą dienų. Galite toliau daryti pakeitimus.
+      recipe_mirrored: Šis ekranas yra atspindėtas iš recepto.
+      recipe_visibility_title: Kaip norėtumėte paskelbti?
+      recipe_visibility_edit_title: Redaguoti pateikimą
+      recipe_visibility_public: Viešas
+      recipe_visibility_public_hint: Kiekvienas gali rasti ir įsidiegti.
+      recipe_visibility_private: Privatus
+      recipe_visibility_private_hint: Nutraukia išorinius įdiegimus.
+      recipe_visibility_unlisted: Neįtrauktas į sąrašą
+      recipe_visibility_unlisted_hint: Įsidiegti gali visi, kas turi nuorodą.
+      refresh_rate: Atnaujinimo dažnis
+      refresh_rate_hint: Nustatykite, kaip dažnai ši įskiepio instancija nuskaito šviežius duomenis
+      refresh_rate_not_configurable: Sinchronizuojama %{refresh_rate} (nekonfigūruojama)
+      refreshed: Atnaujinta
+      remove_plugin: Pašalinti įskiepį
+      remove_plugin_hint: Pašalinus įskiepį, jis taip pat bus pašalintas iš jūsų grojaraščio
+      synced: Sinchronizuota
+      refresh_paused: Atnaujinimas sustabdytas
+      refresh_paused_hint: Automatinis atnaujinimas pristabdytas. Pridėkite prie grojaraščio, kad paleistumėte vėl.
+      refresh_paused_hidden_hint: Automatinis atnaujinimas pristabdytas, nes įskiepis yra paslėptas grojaraštyje. Duomenų sinchronizavimas yra aktyvus.
+      refresh_paused_mashup: Atnaujinami mišiniai (Mashups)
+      refresh_paused_mashup_hint: Automatinis atnaujinimas pristabdytas viso ekrano režimui. Mišiniai atnaujinami.
+      refresh_stopped: Automatinis atnaujinimas sustabdytas. Norėdami tęsti, ištaisykite įskiepio klaidą.
+      view_recipe: Žiūrėti receptą
+      visit_docs: Aplankyti dokumentaciją
+    import:
+      archive_too_large: ZIP failas yra per didelis (maksimaliai %{max_mb} MB)
+      missing_entry: ZIP faile nėra %{filename}
+      entry_too_large: "%{filename} yra per didelis"
+      malformed: "%{filename} yra sugadintas"
+    create:
+      success: Įskiepis sukurtas ir pridėtas prie jūsų
+      playlist: grojaraštis
+    destroy:
+      success: Įskiepis ištrintas
+    handle_canceled_consent: Sutikimas atšauktas, bandykite dar kartą
+    update:
+      success: Įskiepio konfigūracija sėkmingai atnaujinta
+    add_to_playlist:
+      success: Įskiepis pridėtas prie grojaraščio
+  referral_code:
+    create:
+      request_received: Užklausa gauta, patikrinkite savo pašto dėžutę
+  recipes:
+    index:
+      newest_to_oldest: Nuo naujausių iki seniausių
+      oldest_to_newest: Nuo seniausių iki naujausių
+      most_popular: Populiariausi
+      install: Įdiegti
+      fork: Atšakoti (Fork)
+  schedules:
+    form:
+      add: Pridėti pasirinktinį tvarkaraštį
+      append: Ir šiuo metu…
+      no_schedule: Šis ekranas bus rodomas visą laiką.
+      some_schedule: Rodyti šį ekraną tik šiuo metu…
+      to: iki
+      copy_prompt: Kopijuoti tvarkaraštį iš…
+  upgrade:
+    index:
+      title: 'Atnaujinamas įrenginys:'
+      tagline: Atrakinkite pasirinktinius įskiepius ir __daugiau__.
+      pay: Mokėti
+      error: Įrenginys %{device_name} jau yra atnaujintas, pasirinkite kitą įrenginį
+    confirm:
+      success: Kūrėjo versijos priedas dabar įjungtas


### PR DESCRIPTION
## Overview
This PR introduces the official Lithuanian (`lt`) translation for the project. Adding Lithuanian localization is important to make TRMNL accessible to Lithuanian-speaking users and expand the project's global reach. All provided YAML files have been accurately translated while preserving the original structure, dynamic variables (e.g., `%{count}`), and correct pluralization rules suitable for the Lithuanian language.

## Details
- Added full Lithuanian translation for general UI (account settings, dashboard, playlists, devices, and plugins management).
- Translated various specific components including Netatmo weather station, lunar calendar, parcel tracker, and general weather plugins.
- Added localization for custom plugins like simple calendar, world clock, and transport data.
- Handled complex pluralization strings appropriately for the Lithuanian language (using forms for 1, 2-9, and 10+ where necessary in the `public_recipe_stats`).