### PR TITLE
Add calendar translation keys and update unlink_confirm text

### DIFF
--- a/lib/trmnl/i18n/locales/plugin_renders/da.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/da.yml
@@ -3,6 +3,9 @@ da:
   renders:
     and_x_more_prefix: Og
     and_x_more_suffix: mere
+    calendars:
+      no_upcoming_events: No upcoming events
+      no_events_today: No events today
     days_left_year:
       title: Dage tilbage i år
       days_passed: Dage gået

--- a/lib/trmnl/i18n/locales/plugin_renders/de-AT.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/de-AT.yml
@@ -3,6 +3,9 @@ de-AT:
   renders:
     and_x_more_prefix: und
     and_x_more_suffix: weitere
+    calendars:
+      no_upcoming_events: No upcoming events
+      no_events_today: No events today
     days_left_year:
       title: Verbleibende Tage dieses Jahr
       days_passed: Vergangene Tage

--- a/lib/trmnl/i18n/locales/plugin_renders/de.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/de.yml
@@ -3,6 +3,9 @@ de:
   renders:
     and_x_more_prefix: und
     and_x_more_suffix: weitere
+    calendars:
+      no_upcoming_events: No upcoming events
+      no_events_today: No events today
     days_left_year:
       title: Verbleibende Tage dieses Jahr
       days_passed: Vergangene Tage

--- a/lib/trmnl/i18n/locales/plugin_renders/en.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/en.yml
@@ -3,6 +3,9 @@ en:
   renders:
     and_x_more_prefix: And
     and_x_more_suffix: more
+    calendars:
+      no_upcoming_events: No upcoming events
+      no_events_today: No events today
     days_left_year:
       title: Days Left This Year
       days_passed: Days Passed

--- a/lib/trmnl/i18n/locales/plugin_renders/es-ES.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/es-ES.yml
@@ -3,6 +3,9 @@ es-ES:
   renders:
     and_x_more_prefix: "y"
     and_x_more_suffix: más
+    calendars:
+      no_upcoming_events: No upcoming events
+      no_events_today: No events today
     days_left_year:
       title: Días Restantes Este Año
       days_passed: Días Pasados

--- a/lib/trmnl/i18n/locales/plugin_renders/fr.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/fr.yml
@@ -3,6 +3,9 @@ fr:
   renders:
     and_x_more_prefix: Et
     and_x_more_suffix: de plus
+    calendars:
+      no_upcoming_events: No upcoming events
+      no_events_today: No events today
     days_left_year:
       title: Jours restants cette année
       days_passed: Jours passés

--- a/lib/trmnl/i18n/locales/plugin_renders/he.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/he.yml
@@ -3,6 +3,9 @@ he:
   renders:
     and_x_more_prefix: And
     and_x_more_suffix: more
+    calendars:
+      no_upcoming_events: No upcoming events
+      no_events_today: No events today
     days_left_year:
       title: ימים שנותרו עד לסוף השנה
       days_passed: ימים שחלפו

--- a/lib/trmnl/i18n/locales/plugin_renders/hu.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/hu.yml
@@ -3,6 +3,9 @@ hu:
   renders:
     and_x_more_prefix: És
     and_x_more_suffix: további
+    calendars:
+      no_upcoming_events: No upcoming events
+      no_events_today: No events today
     days_left_year:
       title: Hátralévő napok az évben
       days_passed: Eltelt napok

--- a/lib/trmnl/i18n/locales/plugin_renders/id.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/id.yml
@@ -3,6 +3,9 @@ id:
   renders:
     and_x_more_prefix: And
     and_x_more_suffix: more
+    calendars:
+      no_upcoming_events: No upcoming events
+      no_events_today: No events today
     days_left_year:
       title: Days Left This Year
       days_passed: Days Passed

--- a/lib/trmnl/i18n/locales/plugin_renders/is.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/is.yml
@@ -3,6 +3,9 @@ is:
   renders:
     and_x_more_prefix: Og
     and_x_more_suffix: fleiri
+    calendars:
+      no_upcoming_events: No upcoming events
+      no_events_today: No events today
     days_left_year:
       title: Dagar eftir á þessu ári
       days_passed: Dagar liðnir

--- a/lib/trmnl/i18n/locales/plugin_renders/it.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/it.yml
@@ -3,6 +3,9 @@ it:
   renders:
     and_x_more_prefix: e
     and_x_more_suffix: più
+    calendars:
+      no_upcoming_events: No upcoming events
+      no_events_today: No events today
     days_left_year:
       title: Giorni rimasti quest'anno
       days_passed: Giorni Passati

--- a/lib/trmnl/i18n/locales/plugin_renders/ja.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/ja.yml
@@ -3,6 +3,9 @@ ja:
   renders:
     and_x_more_prefix: And
     and_x_more_suffix: more
+    calendars:
+      no_upcoming_events: No upcoming events
+      no_events_today: No events today
     days_left_year:
       title: 今年の残り日数
       days_passed: 経過日数

--- a/lib/trmnl/i18n/locales/plugin_renders/ko.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/ko.yml
@@ -3,6 +3,9 @@ ko:
   renders:
     and_x_more_prefix: ''
     and_x_more_suffix: 개 더
+    calendars:
+      no_upcoming_events: No upcoming events
+      no_events_today: No events today
     days_left_year:
       title: 올해 남은 날
       days_passed: 지난 날

--- a/lib/trmnl/i18n/locales/plugin_renders/lt.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/lt.yml
@@ -3,6 +3,9 @@ lt:
   renders:
     and_x_more_prefix: Ir dar
     and_x_more_suffix: daugiau
+    calendars:
+      no_upcoming_events: No upcoming events
+      no_events_today: No events today
     days_left_year:
       title: Dienų liko šiais metais
       days_passed: Praėjo dienų

--- a/lib/trmnl/i18n/locales/plugin_renders/nl.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/nl.yml
@@ -3,6 +3,9 @@ nl:
   renders:
     and_x_more_prefix: En nog
     and_x_more_suffix:
+    calendars:
+      no_upcoming_events: No upcoming events
+      no_events_today: No events today
     days_left_year:
       title: Dagen over dit jaar
       days_passed: Verstreken dagen

--- a/lib/trmnl/i18n/locales/plugin_renders/no.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/no.yml
@@ -3,6 +3,9 @@
   renders:
     and_x_more_prefix: And
     and_x_more_suffix: more
+    calendars:
+      no_upcoming_events: No upcoming events
+      no_events_today: No events today
     days_left_year:
       title: Dager igjen i år
       days_passed: Dager som har gått

--- a/lib/trmnl/i18n/locales/plugin_renders/pl.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/pl.yml
@@ -3,6 +3,9 @@ pl:
   renders:
     and_x_more_prefix: i
     and_x_more_suffix: więcej
+    calendars:
+      no_upcoming_events: No upcoming events
+      no_events_today: No events today
     days_left_year:
       title: Dni do końca roku
       days_passed: Minęło dni

--- a/lib/trmnl/i18n/locales/plugin_renders/pt-BR.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/pt-BR.yml
@@ -3,6 +3,9 @@ pt-BR:
   renders:
     and_x_more_prefix: E
     and_x_more_suffix: mais
+    calendars:
+      no_upcoming_events: No upcoming events
+      no_events_today: No events today
     days_left_year:
       title: Dias Restantes Neste Ano
       days_passed: Dias Corridos

--- a/lib/trmnl/i18n/locales/plugin_renders/raw.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/raw.yml
@@ -3,6 +3,9 @@ raw:
   renders:
     and_x_more_prefix: renders.and_x_more_prefix
     and_x_more_suffix: renders.and_x_more_suffix
+    calendars:
+      no_upcoming_events: renders.calendars.no_upcoming_events
+      no_events_today: renders.calendars.no_events_today
     days_left_year:
       title: days_left_year.title
       days_passed: days_left_year.title

--- a/lib/trmnl/i18n/locales/plugin_renders/ro.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/ro.yml
@@ -3,6 +3,9 @@ ro:
   renders:
     and_x_more_prefix: Și
     and_x_more_suffix: mai mult
+    calendars:
+      no_upcoming_events: No upcoming events
+      no_events_today: No events today
     days_left_year:
       title: Zile rămase în an
       days_passed: Zile trecute

--- a/lib/trmnl/i18n/locales/plugin_renders/ru.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/ru.yml
@@ -3,6 +3,9 @@ ru:
   renders:
     and_x_more_prefix: И
     and_x_more_suffix: ещё
+    calendars:
+      no_upcoming_events: No upcoming events
+      no_events_today: No events today
     days_left_year:
       title: Осталось дней в этом году
       days_passed: Прошло дней

--- a/lib/trmnl/i18n/locales/plugin_renders/sk.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/sk.yml
@@ -3,6 +3,9 @@ sk:
   renders:
     and_x_more_prefix: A
     and_x_more_suffix: ďalšie
+    calendars:
+      no_upcoming_events: No upcoming events
+      no_events_today: No events today
     days_left_year:
       title: Zostávajúce dni v roku
       days_passed: Uplynuté dni

--- a/lib/trmnl/i18n/locales/plugin_renders/sv.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/sv.yml
@@ -3,6 +3,9 @@ sv:
   renders:
     and_x_more_prefix: And
     and_x_more_suffix: more
+    calendars:
+      no_upcoming_events: No upcoming events
+      no_events_today: No events today
     days_left_year:
       title: Days Left This Year
       days_passed: Days Passed

--- a/lib/trmnl/i18n/locales/plugin_renders/uk.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/uk.yml
@@ -3,6 +3,9 @@ uk:
   renders:
     and_x_more_prefix: And
     and_x_more_suffix: more
+    calendars:
+      no_upcoming_events: No upcoming events
+      no_events_today: No events today
     days_left_year:
       title: Days Left This Year
       days_passed: Days Passed

--- a/lib/trmnl/i18n/locales/plugin_renders/zh-CN.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/zh-CN.yml
@@ -3,6 +3,9 @@ zh-CN:
   renders:
     and_x_more_prefix: 及其他
     and_x_more_suffix: 项
+    calendars:
+      no_upcoming_events: No upcoming events
+      no_events_today: No events today
     days_left_year:
       title: 今年还剩多少天
       days_passed: 已过天数

--- a/lib/trmnl/i18n/locales/plugin_renders/zh-HK.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/zh-HK.yml
@@ -3,6 +3,9 @@ zh-HK:
   renders:
     and_x_more_prefix: 還有
     and_x_more_suffix: 個
+    calendars:
+      no_upcoming_events: No upcoming events
+      no_events_today: No events today
     days_left_year:
       title: 今年剩餘日數
       days_passed: 經過日數

--- a/lib/trmnl/i18n/locales/web_ui/da.yml
+++ b/lib/trmnl/i18n/locales/web_ui/da.yml
@@ -290,7 +290,7 @@ da:
       tidbyt_device_id: Device ID
       tidbyt_device_api_key: API Key
       unlink: Fjern tilknytning
-      unlink_confirm: Er du sikker? Dette sletter alle plugin-indstillinger og playliste-elementer, så enheden kan tilknyttes en anden konto.
+      unlink_confirm: Are you sure? Only proceed if you are giving this device to someone else or switching to BYOS. Unpairing deletes all plugin settings and playlist items. If troubleshooting, contact support at help.trmnl.com.
       unlink_device: Fjern tilknytning til enhed
       unlink_device_hint: At fjerne tilknytning gør det sikkert at sælge eller give TRMNL-enheden til en anden.
       unlink_device_learn_more: Følg den fulde guide __her__.

--- a/lib/trmnl/i18n/locales/web_ui/de-AT.yml
+++ b/lib/trmnl/i18n/locales/web_ui/de-AT.yml
@@ -290,7 +290,7 @@ de-AT:
       tidbyt_device_id: Geräte-ID
       tidbyt_device_api_key: API-Schlüssel
       unlink: Entkoppeln
-      unlink_confirm: Bist du sicher? Hiermit werden alle Erweiterungseinstellungen und Einträge der Wiedergabeliste gelöscht, um das Gerät einem anderen Konto zuzuordnen.
+      unlink_confirm: Are you sure? Only proceed if you are giving this device to someone else or switching to BYOS. Unpairing deletes all plugin settings and playlist items. If troubleshooting, contact support at help.trmnl.com.
       unlink_device: Gerät entkoppeln
       unlink_device_hint: Verbindung zu einem TRMNL-Gerät entfernen, um es sicher zu verkaufen oder weiterzugeben.
       unlink_device_learn_more: __Hier__ gibt es die vollständige Anleitung dazu.

--- a/lib/trmnl/i18n/locales/web_ui/de.yml
+++ b/lib/trmnl/i18n/locales/web_ui/de.yml
@@ -290,7 +290,7 @@ de:
       tidbyt_device_id: Geräte-ID
       tidbyt_device_api_key: API-Schlüssel
       unlink: Entkoppeln
-      unlink_confirm: Bist du sicher? Hiermit werden alle Erweiterungseinstellungen und Einträge der Wiedergabeliste gelöscht, um das Gerät einem anderen Konto zuzuordnen.
+      unlink_confirm: Are you sure? Only proceed if you are giving this device to someone else or switching to BYOS. Unpairing deletes all plugin settings and playlist items. If troubleshooting, contact support at help.trmnl.com.
       unlink_device: Gerät entkoppeln
       unlink_device_hint: Verbindung zu einem TRMNL-Gerät entfernen, um es sicher zu verkaufen oder weiterzugeben.
       unlink_device_learn_more: __Hier__ gibt es die vollständige Anleitung dazu.

--- a/lib/trmnl/i18n/locales/web_ui/en-GB.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en-GB.yml
@@ -290,7 +290,7 @@ en-GB:
       tidbyt_device_id: Device ID
       tidbyt_device_api_key: API Key
       unlink: Unlink
-      unlink_confirm: Are you sure? This will delete all underlying plugin settings and playlist items, so the device can be added to another account.
+      unlink_confirm: Are you sure? Only proceed if you are giving this device to someone else or switching to BYOS. Unpairing deletes all plugin settings and playlist items. If troubleshooting, contact support at help.trmnl.com.
       unlink_device: Unlink Device
       unlink_device_hint: Unlinking a TRMNL device makes it safe to re-sell or give to someone else.
       unlink_device_learn_more: Follow the full guide __here__.

--- a/lib/trmnl/i18n/locales/web_ui/es-ES.yml
+++ b/lib/trmnl/i18n/locales/web_ui/es-ES.yml
@@ -290,7 +290,7 @@ es-ES:
       tidbyt_device_id: ID del dispositivo
       tidbyt_device_api_key: Clave API
       unlink: Desvincular
-      unlink_confirm: "¿Estás seguro? Esto borrará todas las configuraciones de los plugins y los elementos de la lista de reproducción, para que el dispositivo pueda ser añadido a otra cuenta."
+      unlink_confirm: Are you sure? Only proceed if you are giving this device to someone else or switching to BYOS. Unpairing deletes all plugin settings and playlist items. If troubleshooting, contact support at help.trmnl.com.
       unlink_device: Desvincular dispositivo
       unlink_device_hint: Desvincular un dispositivo TRMNL lo hace seguro para revender o regalar a otra persona.
       unlink_device_learn_more: Sigue la guía completa __aquí__.

--- a/lib/trmnl/i18n/locales/web_ui/fr.yml
+++ b/lib/trmnl/i18n/locales/web_ui/fr.yml
@@ -292,7 +292,7 @@ fr:
       tidbyt_device_id: ID de l'appareil
       tidbyt_device_api_key: Clé API
       unlink: Dissocier
-      unlink_confirm: Êtes-vous sûr ? Cela supprimera tous les paramètres de plugins et éléments de playlist sous-jacents, afin que l'appareil puisse être ajouté à un autre compte.
+      unlink_confirm: Are you sure? Only proceed if you are giving this device to someone else or switching to BYOS. Unpairing deletes all plugin settings and playlist items. If troubleshooting, contact support at help.trmnl.com.
       unlink_device: Dissocier l'appareil
       unlink_device_hint: Dissocier un appareil TRMNL permet de le revendre ou de le donner en toute sécurité.
       unlink_device_learn_more: Suivez le guide complet __ici__.

--- a/lib/trmnl/i18n/locales/web_ui/he.yml
+++ b/lib/trmnl/i18n/locales/web_ui/he.yml
@@ -292,7 +292,7 @@ he:
       tidbyt_device_id: Device ID
       tidbyt_device_api_key: API Key
       unlink: Unlink
-      unlink_confirm: Are you sure? This will delete all underlying plugin settings and playlist items, so the device can be added to another account.
+      unlink_confirm: Are you sure? Only proceed if you are giving this device to someone else or switching to BYOS. Unpairing deletes all plugin settings and playlist items. If troubleshooting, contact support at help.trmnl.com.
       unlink_device: Unlink Device
       unlink_device_hint: Unlinking a TRMNL device makes it safe to re-sell or give to someone else.
       unlink_device_learn_more: Follow the full guide __here__.

--- a/lib/trmnl/i18n/locales/web_ui/hu.yml
+++ b/lib/trmnl/i18n/locales/web_ui/hu.yml
@@ -290,7 +290,7 @@ hu:
       tidbyt_device_id: Device ID
       tidbyt_device_api_key: API Key
       unlink: Leválasztás
-      unlink_confirm: Biztos vagy benne? Ez törli az összes kapcsolódó bővítménybeállítást és lejátszási listát, hogy az eszközt másik fiókhoz lehessen adni.
+      unlink_confirm: Are you sure? Only proceed if you are giving this device to someone else or switching to BYOS. Unpairing deletes all plugin settings and playlist items. If troubleshooting, contact support at help.trmnl.com.
       unlink_device: Eszköz leválasztása
       unlink_device_hint: A TRMNL leválasztása biztonságossá teszi az újraértékesítést vagy ajándékozást.
       unlink_device_learn_more: Kövesd a teljes útmutatót __itt__.

--- a/lib/trmnl/i18n/locales/web_ui/id.yml
+++ b/lib/trmnl/i18n/locales/web_ui/id.yml
@@ -292,7 +292,7 @@ id:
       tidbyt_device_id: Device ID
       tidbyt_device_api_key: API Key
       unlink: Lepas Tautan
-      unlink_confirm: Are you sure? This will delete all underlying plugin settings and playlist items, so the device can be added to another account.
+      unlink_confirm: Are you sure? Only proceed if you are giving this device to someone else or switching to BYOS. Unpairing deletes all plugin settings and playlist items. If troubleshooting, contact support at help.trmnl.com.
       unlink_device: Lepaskan Tautan Perangkat
       unlink_device_hint: Lepaskan tautan perangkat TRMNL agar aman untuk dijual kembali atau diberikan kepada orang lain.
       unlink_device_learn_more: Follow the full guide __here__.

--- a/lib/trmnl/i18n/locales/web_ui/is.yml
+++ b/lib/trmnl/i18n/locales/web_ui/is.yml
@@ -290,7 +290,7 @@ is:
       tidbyt_device_id: Device ID
       tidbyt_device_api_key: API Key
       unlink: Aftengja
-      unlink_confirm: Ertu viss? Þetta eyðir öllum viðbótarstillingum og spilunarlistum svo tækið geti verið tengt við annan aðgang.
+      unlink_confirm: Are you sure? Only proceed if you are giving this device to someone else or switching to BYOS. Unpairing deletes all plugin settings and playlist items. If troubleshooting, contact support at help.trmnl.com.
       unlink_device: Aftengja tæki
       unlink_device_hint: Aftenging gerir tækið öruggt til endursölu eða afhendingar til annars aðila.
       unlink_device_learn_more: Fylgdu leiðbeiningum __hér__.

--- a/lib/trmnl/i18n/locales/web_ui/it.yml
+++ b/lib/trmnl/i18n/locales/web_ui/it.yml
@@ -290,7 +290,7 @@ it:
       tidbyt_device_id: ID Dispositivo
       tidbyt_device_api_key: Chiave API
       unlink: Scollega
-      unlink_confirm: Sei sicuro? Verranno eliminate tutte le impostazioni dei plugin e gli oggetti nelle playlist per permettere di aggiungere questo dispositivi ad un altro account.
+      unlink_confirm: Are you sure? Only proceed if you are giving this device to someone else or switching to BYOS. Unpairing deletes all plugin settings and playlist items. If troubleshooting, contact support at help.trmnl.com.
       unlink_device: Scollega Dispositivo
       unlink_device_hint: Scollegare un dispositivo TRMNL rende sicuro rivenderlo o darlo a qualcun altro.
       unlink_device_learn_more: Segui la guida completa __qui__.

--- a/lib/trmnl/i18n/locales/web_ui/ja.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ja.yml
@@ -290,7 +290,7 @@ ja:
       tidbyt_device_id: Device ID
       tidbyt_device_api_key: API Key
       unlink: 接続解除
-      unlink_confirm: Are you sure? This will delete all underlying plugin settings and playlist items, so the device can be added to another account.
+      unlink_confirm: Are you sure? Only proceed if you are giving this device to someone else or switching to BYOS. Unpairing deletes all plugin settings and playlist items. If troubleshooting, contact support at help.trmnl.com.
       unlink_device: デバイス接続を解除する
       unlink_device_hint: TRMNLデバイスの接続を解除すると、デバイスを再販したり贈ったりするときにより安全です。
       unlink_device_learn_more: Follow the full guide __here__.

--- a/lib/trmnl/i18n/locales/web_ui/nl.yml
+++ b/lib/trmnl/i18n/locales/web_ui/nl.yml
@@ -290,7 +290,7 @@ nl:
       tidbyt_device_id: Device ID
       tidbyt_device_api_key: API Key
       unlink: Ontkoppelen
-      unlink_confirm: Weet je het zeker? Dit zal alle plugin instellingen en afspeellijsten verwijderen, zodat je het device aan een nieuw account kan koppelen.
+      unlink_confirm: Are you sure? Only proceed if you are giving this device to someone else or switching to BYOS. Unpairing deletes all plugin settings and playlist items. If troubleshooting, contact support at help.trmnl.com.
       unlink_device: Apparaat ontkoppelen
       unlink_device_hint: Door een TRMNL apparaat te ontkoppelen kun je hem veilig verkopen of aan iemand anders geven.
       unlink_device_learn_more: Volg __hier__ de volledige handleiding.

--- a/lib/trmnl/i18n/locales/web_ui/no.yml
+++ b/lib/trmnl/i18n/locales/web_ui/no.yml
@@ -290,7 +290,7 @@
       tidbyt_device_id: Device ID
       tidbyt_device_api_key: API Key
       unlink: Koble fra
-      unlink_confirm: Are you sure? This will delete all underlying plugin settings and playlist items, so the device can be added to another account.
+      unlink_confirm: Are you sure? Only proceed if you are giving this device to someone else or switching to BYOS. Unpairing deletes all plugin settings and playlist items. If troubleshooting, contact support at help.trmnl.com.
       unlink_device: Koble fra enhet
       unlink_device_hint: Å koble fra en TRMNL-enhet gjør den trygg å selge videre eller gi bort.
       unlink_device_learn_more: Follow the full guide __here__.

--- a/lib/trmnl/i18n/locales/web_ui/pl.yml
+++ b/lib/trmnl/i18n/locales/web_ui/pl.yml
@@ -312,7 +312,7 @@ pl:
       tidbyt_device_id: ID urządzenia
       tidbyt_device_api_key: Klucz API
       unlink: Odłącz
-      unlink_confirm: Czy na pewno chcesz to zrobić? To usunie wszystkie ustawienia pluginów i elementy playlist. Umożliwi to dołączenie urządzenia do innego konta.
+      unlink_confirm: Are you sure? Only proceed if you are giving this device to someone else or switching to BYOS. Unpairing deletes all plugin settings and playlist items. If troubleshooting, contact support at help.trmnl.com.
       unlink_device: Odłącz urządzenie
       unlink_device_hint: Odłączenie urządzenia TRMNL od konta sprawia, że można bezpiecznie je sprzedać lub komuś podarować.
       unlink_device_learn_more: Szczegółowe informacje znajdziesz __tutaj__.

--- a/lib/trmnl/i18n/locales/web_ui/pt-BR.yml
+++ b/lib/trmnl/i18n/locales/web_ui/pt-BR.yml
@@ -290,7 +290,7 @@ pt-BR:
       tidbyt_device_id: Device ID
       tidbyt_device_api_key: API Key
       unlink: Desconectar
-      unlink_confirm: Tem certeza? Isso irá deletar todas as configurações de plugins e playlists, para que o dispositivo possa ser adicionado a outra conta.
+      unlink_confirm: Are you sure? Only proceed if you are giving this device to someone else or switching to BYOS. Unpairing deletes all plugin settings and playlist items. If troubleshooting, contact support at help.trmnl.com.
       unlink_device: Desconectar Dispositivo
       unlink_device_hint: Desconectar um TRMNL permite revendê-lo ou dá-lo a outra pessoa com segurança.
       unlink_device_learn_more: Siga o guia completo __aqui__.

--- a/lib/trmnl/i18n/locales/web_ui/ru.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ru.yml
@@ -312,7 +312,7 @@ ru:
       tidbyt_device_id: Device ID
       tidbyt_device_api_key: API Key
       unlink: Отвязать
-      unlink_confirm: Вы уверены? Это приведет к удалению всех основных настроек плагинов и элементов плейлиста, чтобы устройство можно было добавить в другую учётную запись.
+      unlink_confirm: Are you sure? Only proceed if you are giving this device to someone else or switching to BYOS. Unpairing deletes all plugin settings and playlist items. If troubleshooting, contact support at help.trmnl.com.
       unlink_device: Отвязать устройство
       unlink_device_hint: Отвязка TRMNL делает его безопасным для перепродажи или передачи кому-либо ещё.
       unlink_device_learn_more: Следуйте полному руководству __здесь__.

--- a/lib/trmnl/i18n/locales/web_ui/sk.yml
+++ b/lib/trmnl/i18n/locales/web_ui/sk.yml
@@ -301,7 +301,7 @@ sk:
       tidbyt_device_id: Device ID
       tidbyt_device_api_key: API Key
       unlink: Unlink
-      unlink_confirm: Are you sure? This will delete all underlying plugin settings and playlist items, so the device can be added to another account.
+      unlink_confirm: Are you sure? Only proceed if you are giving this device to someone else or switching to BYOS. Unpairing deletes all plugin settings and playlist items. If troubleshooting, contact support at help.trmnl.com.
       unlink_device: Unlink Device
       unlink_device_hint: Unlinking a TRMNL makes it safe to re-sell or give to someone else.
       unlink_device_learn_more: Follow the full guide __here__.

--- a/lib/trmnl/i18n/locales/web_ui/sv.yml
+++ b/lib/trmnl/i18n/locales/web_ui/sv.yml
@@ -290,7 +290,7 @@ sv:
       tidbyt_device_id: Device ID
       tidbyt_device_api_key: API Key
       unlink: Unlink
-      unlink_confirm: Are you sure? This will delete all underlying plugin settings and playlist items, so the device can be added to another account.
+      unlink_confirm: Are you sure? Only proceed if you are giving this device to someone else or switching to BYOS. Unpairing deletes all plugin settings and playlist items. If troubleshooting, contact support at help.trmnl.com.
       unlink_device: Unlink Device
       unlink_device_hint: Unlinking a TRMNL makes it safe to re-sell or give to someone else.
       unlink_device_learn_more: Follow the full guide __here__.

--- a/lib/trmnl/i18n/locales/web_ui/uk.yml
+++ b/lib/trmnl/i18n/locales/web_ui/uk.yml
@@ -312,7 +312,7 @@ uk:
       tidbyt_device_id: Device ID
       tidbyt_device_api_key: API Key
       unlink: Відв'язати
-      unlink_confirm: Are you sure? This will delete all underlying plugin settings and playlist items, so the device can be added to another account.
+      unlink_confirm: Are you sure? Only proceed if you are giving this device to someone else or switching to BYOS. Unpairing deletes all plugin settings and playlist items. If troubleshooting, contact support at help.trmnl.com.
       unlink_device: Відв'язати пристрій
       unlink_device_hint: Відв'язування пристрою TRMNL робить його безпечним для перепродажу або передачі іншій особі.
       unlink_device_learn_more: Follow the full guide __here__.

--- a/lib/trmnl/i18n/locales/web_ui/zh-CN.yml
+++ b/lib/trmnl/i18n/locales/web_ui/zh-CN.yml
@@ -325,7 +325,7 @@ zh-CN:
       tidbyt_device_id: 设备 ID
       tidbyt_device_api_key: API 密钥
       unlink: 解绑
-      unlink_confirm: 您确定吗？此操作将删除所有基础插件设置和播放列表项目，以便该设备可添加至其他账户。
+      unlink_confirm: Are you sure? Only proceed if you are giving this device to someone else or switching to BYOS. Unpairing deletes all plugin settings and playlist items. If troubleshooting, contact support at help.trmnl.com.
       unlink_device: 解绑设备
       unlink_device_hint: 解绑TRMNL设备以转移用户
       unlink_device_learn_more: __点击此处__阅读完整说明。

--- a/lib/trmnl/i18n/locales/web_ui/zh-HK.yml
+++ b/lib/trmnl/i18n/locales/web_ui/zh-HK.yml
@@ -290,7 +290,7 @@ zh-HK:
       tidbyt_device_id: 裝置ID
       tidbyt_device_api_key: API金鑰
       unlink: 取消連結
-      unlink_confirm: 確定嗎？這將刪除所有相關的外掛設定及播放清單項目，以便裝置加入另一個帳戶。
+      unlink_confirm: Are you sure? Only proceed if you are giving this device to someone else or switching to BYOS. Unpairing deletes all plugin settings and playlist items. If troubleshooting, contact support at help.trmnl.com.
       unlink_device: 取消連結裝置
       unlink_device_hint: 取消連結TRMNL後，可安全地轉售或贈送他人。
       unlink_device_learn_more: __按此__查看完整指南。


### PR DESCRIPTION
- Add `calendars.no_upcoming_events` and `calendars.no_events_today` translation keys to all `plugin_renders` locales (to compliment this PR: https://github.com/usetrmnl/core/pull/2695)
- Update `unlink_confirm` text across all `web_ui` locales to the revised English copy (clarifies when to unpair and directs users to support), i.e. needs a new translation for some languages, but will make sure users see this (important) message
