### PR TITLE
Add /devices translation keys

### DIFF
--- a/lib/trmnl/i18n/locales/web_ui/da.yml
+++ b/lib/trmnl/i18n/locales/web_ui/da.yml
@@ -315,6 +315,7 @@ da:
       tagline: Dine TRMNL-enheder
       add_device_modal_title: Tilføj en ny enhed
       add_first_device: Start med at tilføje din første enhed!
+      go_to_settings: Go to settings
     new:
       title: Tilføj en ny enhed
       description: Indtast dit enheds-ID for at tilføje en ny TRMNL-enhed til din konto.
@@ -340,6 +341,7 @@ da:
     switch:
       error: Fejl ved skift af enhed
       success: Enhed skiftet med succes
+      title: Switch to device
     update:
       error: Fejl ved opdatering af enhed
       success: "%{device} enhedsindstillinger opdateret med succes"

--- a/lib/trmnl/i18n/locales/web_ui/de-AT.yml
+++ b/lib/trmnl/i18n/locales/web_ui/de-AT.yml
@@ -315,6 +315,7 @@ de-AT:
       tagline: Deine TRMNL-Geräte
       add_device_modal_title: Neues Gerät hinzufügen
       add_first_device: Beginne mit dem Hinzufügen deines ersten Gerätes!
+      go_to_settings: Go to settings
     new:
       title: Neues Gerät hinzufügen
       description: Gib deine Gerätekennung ein, um ein neues Gerät zu deinem Konto hinzuzufügen.
@@ -340,6 +341,7 @@ de-AT:
     switch:
       error: Fehler beim Wechseln des Gerätes
       success: Gerät erfolgreich gewechselt
+      title: Switch to device
     update:
       error: Fehler beim Aktualisieren des Gerätes
       success: Einstellungen von %{device} erfolgreich aktualisiert

--- a/lib/trmnl/i18n/locales/web_ui/de.yml
+++ b/lib/trmnl/i18n/locales/web_ui/de.yml
@@ -315,6 +315,7 @@ de:
       tagline: Deine TRMNL-Geräte
       add_device_modal_title: Neues Gerät hinzufügen
       add_first_device: Beginne mit dem Hinzufügen deines ersten Gerätes!
+      go_to_settings: Go to settings
     new:
       title: Neues Gerät hinzufügen
       description: Gib deine Gerätekennung ein, um ein neues Gerät zu deinem Konto hinzuzufügen.
@@ -340,6 +341,7 @@ de:
     switch:
       error: Fehler beim Wechseln des Gerätes
       success: Gerät erfolgreich gewechselt
+      title: Switch to device
     update:
       error: Fehler beim Aktualisieren des Gerätes
       success: Einstellungen von %{device} erfolgreich aktualisiert

--- a/lib/trmnl/i18n/locales/web_ui/en-GB.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en-GB.yml
@@ -315,6 +315,7 @@ en-GB:
       tagline: Your TRMNL devices
       add_device_modal_title: Add a new device
       add_first_device: Start by adding your first device!
+      go_to_settings: Go to settings
     new:
       title: Add a new device
       description: Enter your Friendly ID to add a new device to your account.
@@ -340,6 +341,7 @@ en-GB:
     switch:
       error: Error switching device
       success: Device switched successfully
+      title: Switch to device
     update:
       error: Error updating device
       success: "%{device} device settings updated successfully"

--- a/lib/trmnl/i18n/locales/web_ui/en.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en.yml
@@ -315,6 +315,7 @@ en:
       tagline: Your TRMNL devices
       add_device_modal_title: Add a new device
       add_first_device: Start by adding your first device!
+      go_to_settings: Go to settings
     new:
       title: Add a new device
       description: Enter your Friendly ID to add a new device to your account.
@@ -340,6 +341,7 @@ en:
     switch:
       error: Error switching device
       success: Device switched successfully
+      title: Switch to device
     update:
       error: Error updating device
       success: "%{device} device settings updated successfully"

--- a/lib/trmnl/i18n/locales/web_ui/es-ES.yml
+++ b/lib/trmnl/i18n/locales/web_ui/es-ES.yml
@@ -315,6 +315,7 @@ es-ES:
       tagline: Tus dispositivos TRMNL
       add_device_modal_title: Añadir un nuevo dispositivo
       add_first_device: "¡Añade tu primer dispositivo!"
+      go_to_settings: Go to settings
     new:
       title: Añadir un nuevo dispositivo
       description: Introduce tu ID de Dispositivo para añadir un nuevo dispositivo TRMNL a tu cuenta.
@@ -340,6 +341,7 @@ es-ES:
     switch:
       error: Error al cambiar de dispositivo
       success: Dispositivo cambiado con éxito
+      title: Switch to device
     update:
       error: Error al actualizar el dispositivo
       success: Configuración del dispositivo %{device} actualizada con éxito

--- a/lib/trmnl/i18n/locales/web_ui/fr.yml
+++ b/lib/trmnl/i18n/locales/web_ui/fr.yml
@@ -317,6 +317,7 @@ fr:
       tagline: Vos appareils TRMNL
       add_device_modal_title: Ajouter un nouvel appareil
       add_first_device: Commencez en ajoutant votre premier appareil !
+      go_to_settings: Go to settings
     new:
       title: Ajouter un nouvel appareil
       description: Entrez votre ID d'appareil pour ajouter un nouveau TRMNL à votre compte.
@@ -342,6 +343,7 @@ fr:
     switch:
       error: Erreur lors du changement d'appareil
       success: Appareil changé avec succès
+      title: Switch to device
     update:
       error: Erreur lors de la mise à jour de l'appareil
       success: "%{device} mis à jour avec succès"

--- a/lib/trmnl/i18n/locales/web_ui/he.yml
+++ b/lib/trmnl/i18n/locales/web_ui/he.yml
@@ -317,6 +317,7 @@ he:
       tagline: Your TRMNL devices
       add_device_modal_title: Add a new device
       add_first_device: Start by adding your first device!
+      go_to_settings: Go to settings
     new:
       title: Add a new device
       description: Enter your Friendly ID to add a new device to your account.
@@ -342,6 +343,7 @@ he:
     switch:
       error: Error switching device
       success: Device switched successfully
+      title: Switch to device
     update:
       error: Error updating device
       success: "%{device} device settings updated successfully"

--- a/lib/trmnl/i18n/locales/web_ui/hu.yml
+++ b/lib/trmnl/i18n/locales/web_ui/hu.yml
@@ -315,6 +315,7 @@ hu:
       tagline: A te TRMNL eszközeid
       add_device_modal_title: Új eszköz hozzáadása
       add_first_device: Kezdd az első eszközöd hozzáadásával!
+      go_to_settings: Go to settings
     new:
       title: Új eszköz hozzáadása
       description: Add meg az eszközazonosítót, hogy új TRMNL eszközt kapcsolj a fiókodhoz.
@@ -340,6 +341,7 @@ hu:
     switch:
       error: Hiba az eszközváltáskor
       success: Az eszköz sikeresen átváltva
+      title: Switch to device
     update:
       error: Hiba az eszköz frissítésekor
       success: "%{device} eszközbeállításai sikeresen frissítve"

--- a/lib/trmnl/i18n/locales/web_ui/id.yml
+++ b/lib/trmnl/i18n/locales/web_ui/id.yml
@@ -317,6 +317,7 @@ id:
       tagline: Perangkat TRMNL Anda
       add_device_modal_title: Tambah perangkat baru
       add_first_device: Mulai dengan menambahkan perangkat pertama Anda!
+      go_to_settings: Go to settings
     new:
       title: Tambah perangkat baru
       description: Masukkan ID Perangkat Anda untuk menambahkan perangkat TRMNL baru ke akun Anda.
@@ -342,6 +343,7 @@ id:
     switch:
       error: Terjadi kesalahan saat mengganti perangkat
       success: Perangkat berhasil diganti
+      title: Switch to device
     update:
       error: Terjadi kesalahan saat memperbarui perangkat
       success: Pengaturan perangkat %{device} berhasil diperbarui

--- a/lib/trmnl/i18n/locales/web_ui/is.yml
+++ b/lib/trmnl/i18n/locales/web_ui/is.yml
@@ -315,6 +315,7 @@ is:
       tagline: TRMNL tækin þín
       add_device_modal_title: Bæta við nýju tæki
       add_first_device: Byrjaðu á því að bæta við fyrsta tækinu þínu!
+      go_to_settings: Go to settings
     new:
       title: Bæta við nýju tæki
       description: Sláðu inn kennimerki tækis til að bæta TRMNL tæki við aðganginn þinn.
@@ -340,6 +341,7 @@ is:
     switch:
       error: Villa við skiptingu tækis
       success: Tæki skipt
+      title: Switch to device
     update:
       error: Villa við að uppfæra tæki
       success: Stillingar tækis %{device} uppfærðar

--- a/lib/trmnl/i18n/locales/web_ui/it.yml
+++ b/lib/trmnl/i18n/locales/web_ui/it.yml
@@ -315,6 +315,7 @@ it:
       tagline: I tuoi dispositivi TRMNL
       add_device_modal_title: Aggiungi un nuovo dispositivo
       add_first_device: Inizia aggiungendo il tuo primo dispositivo!
+      go_to_settings: Go to settings
     new:
       title: Aggiungi un nuovo dispositivo
       description: Immetti l'ID del dispositivo per aggiungere un nuovo dispositivo TRMNL al tuo profilo.
@@ -340,6 +341,7 @@ it:
     switch:
       error: Errore nel cambio dispositivo
       success: Dispositivo cambiato
+      title: Switch to device
     update:
       error: Errore nell'aggiornamento del dispositivo
       success: "%{device} impostazioni dispositivo aggiornate con successo"

--- a/lib/trmnl/i18n/locales/web_ui/ja.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ja.yml
@@ -315,6 +315,7 @@ ja:
       tagline: あなたのTRMNLデバイス
       add_device_modal_title: 新しいデバイスを追加
       add_first_device: 始めるには最初のデバイスを追加してください！
+      go_to_settings: Go to settings
     new:
       title: 新しいデバイスを追加
       description: デバイスIDを入力して、新しいTRMNLデバイスをアカウントに追加してください。
@@ -340,6 +341,7 @@ ja:
     switch:
       error: デバイス切り替えエラー
       success: デバイスが正常に切り替えられました
+      title: Switch to device
     update:
       error: デバイス更新エラー
       success: "%{device}デバイスの設定が正常に更新されました"

--- a/lib/trmnl/i18n/locales/web_ui/ko.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ko.yml
@@ -315,6 +315,7 @@ ko:
       tagline: 내 TRMNL 기기
       add_device_modal_title: 새 기기 추가하기
       add_first_device: 첫 기기를 추가해서 시작하세요!
+      go_to_settings: Go to settings
     new:
       title: 새 기기 추가하기
       description: Friendly ID를 입력해서 새 기기를 계정에 추가하세요.
@@ -340,6 +341,7 @@ ko:
     switch:
       error: 기기 변경 오류
       success: 기기를 변경했어요
+      title: Switch to device
     update:
       error: 기기 업데이트 오류
       success: "%{device} 기기 설정을 업데이트했어요"

--- a/lib/trmnl/i18n/locales/web_ui/lt.yml
+++ b/lib/trmnl/i18n/locales/web_ui/lt.yml
@@ -315,6 +315,7 @@ lt:
       tagline: Jūsų TRMNL įrenginiai
       add_device_modal_title: Pridėti naują įrenginį
       add_first_device: Pradėkite pridėdami savo pirmąjį įrenginį!
+      go_to_settings: Go to settings
     new:
       title: Pridėti naują įrenginį
       description: Įveskite savo Friendly ID, kad pridėtumėte naują įrenginį prie savo paskyros.
@@ -340,6 +341,7 @@ lt:
     switch:
       error: Klaida perjungiant įrenginį
       success: Įrenginys sėkmingai perjungtas
+      title: Switch to device
     update:
       error: Klaida atnaujinant įrenginį
       success: "%{device} įrenginio nustatymai sėkmingai atnaujinti"

--- a/lib/trmnl/i18n/locales/web_ui/nl.yml
+++ b/lib/trmnl/i18n/locales/web_ui/nl.yml
@@ -315,6 +315,7 @@ nl:
       tagline: Jouw TRMNL apparaten
       add_device_modal_title: Nieuw apparaat toevoegen
       add_first_device: Begin door jouw eerste apparaat toe te voegen!
+      go_to_settings: Go to settings
     new:
       title: Nieuw apparaat toevoegen
       description: Voer je Apparaat ID in om een nieuw TRMNL apparaat aan je account toe te voegen.
@@ -340,6 +341,7 @@ nl:
     switch:
       error: Fout bij wisselen apparaat
       success: Apparaat succesvol gewisseld
+      title: Switch to device
     update:
       error: Fout bij updaten apparaat
       success: "%{device} apparaatinstellingen succesvol bijgewerkt"

--- a/lib/trmnl/i18n/locales/web_ui/no.yml
+++ b/lib/trmnl/i18n/locales/web_ui/no.yml
@@ -315,6 +315,7 @@
       tagline: Dine TRMNL-enheter
       add_device_modal_title: Legg til en ny enhet
       add_first_device: Start med å legge til din første enhet!
+      go_to_settings: Go to settings
     new:
       title: Legg til en ny enhet
       description: Skriv inn din enhets-ID for å legge til en ny TRMNL-enhet til kontoen din.
@@ -340,6 +341,7 @@
     switch:
       error: Feil ved bytting av enhet
       success: Enheten ble byttet
+      title: Switch to device
     update:
       error: Feil ved oppdatering av enhet
       success: "%{device} enhetsinnstillingene ble oppdatert"

--- a/lib/trmnl/i18n/locales/web_ui/pl.yml
+++ b/lib/trmnl/i18n/locales/web_ui/pl.yml
@@ -337,6 +337,7 @@ pl:
       tagline: Twoje urządzenia TRMNL
       add_device_modal_title: Dodaj nowe urządzenie
       add_first_device: Zacznij, dodając swoje pierwsze urządzenie!
+      go_to_settings: Go to settings
     new:
       title: Dodaj nowe urządzenie
       description: Wprowadź swoje Przyjazne ID, aby przypisać nowe urządzenie do tego konta.
@@ -362,6 +363,7 @@ pl:
     switch:
       error: Błąd przy przełączaniu urządzenia
       success: Pomyślnie przełączono urządzenie
+      title: Switch to device
     update:
       error: Błąd podczas aktualizacji urządzenia
       success: Ustawienia urządzenia %{device} zostały pomyślnie zaktualizowane

--- a/lib/trmnl/i18n/locales/web_ui/pt-BR.yml
+++ b/lib/trmnl/i18n/locales/web_ui/pt-BR.yml
@@ -315,6 +315,7 @@ pt-BR:
       tagline: Seus dispositivos TRMNL
       add_device_modal_title: Adicionar novo dispositivo
       add_first_device: Comece adicionando seu primeiro dispositivo!
+      go_to_settings: Go to settings
     new:
       title: Adicionar novo dispositivo
       description: Coloque o ID do Dispositivo para adicionar um novo TRMNL à sua conta.
@@ -340,6 +341,7 @@ pt-BR:
     switch:
       error: Erro ao trocar dispositivo
       success: Dispositivo trocado com sucesso
+      title: Switch to device
     update:
       error: Erro ao atualizar dispositivo
       success: Configurações do dispositivo %{device} atualizadas com sucesso

--- a/lib/trmnl/i18n/locales/web_ui/raw.yml
+++ b/lib/trmnl/i18n/locales/web_ui/raw.yml
@@ -315,6 +315,7 @@ raw:
       tagline: devices.index.tagline
       add_device_modal_title: devices.index.add_device_modal_title
       add_first_device: devices.index.add_first_device
+      go_to_settings: devices.index.go_to_settings
     new:
       title: devices.new.title
       description: devices.new.description
@@ -340,6 +341,7 @@ raw:
     switch:
       error: devices.switch.error
       success: devices.switch.success
+      title: devices.switch.title
     update:
       error: devices.update.error
       success: devices.update.success

--- a/lib/trmnl/i18n/locales/web_ui/ro.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ro.yml
@@ -315,6 +315,7 @@ ro:
       tagline: Dispozitivele tale TRMNL
       add_device_modal_title: Adaugă un dispozitiv nou
       add_first_device: Începe prin a adăuga primul tău dispozitiv!
+      go_to_settings: Go to settings
     new:
       title: Adaugă un dispozitiv nou
       description: Introdu ID-ul prietenos pentru a adăuga un dispozitiv nou în contul tău.
@@ -340,6 +341,7 @@ ro:
     switch:
       error: Eroare la schimbarea dispozitivului
       success: Dispozitiv schimbat cu succes
+      title: Switch to device
     update:
       error: Eroare la actualizarea dispozitivului
       success: Setările dispozitivului %{device} actualizate cu succes

--- a/lib/trmnl/i18n/locales/web_ui/ru.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ru.yml
@@ -337,6 +337,7 @@ ru:
       tagline: Ваши устройства TRMNL
       add_device_modal_title: Добавить новое устройство
       add_first_device: Начните с добавления вашего первого устройства!
+      go_to_settings: Go to settings
     new:
       title: Добавить новое устройство
       description: Введите свой Дружелюбный ID, чтобы добавить новое устройство в свою учётную запись.
@@ -362,6 +363,7 @@ ru:
     switch:
       error: Ошибка переключения устройства
       success: Устройство успешно переключено
+      title: Switch to device
     update:
       error: Ошибка обновления устройства
       success: Настройки устройства "%{device}" успешно обновлены

--- a/lib/trmnl/i18n/locales/web_ui/sk.yml
+++ b/lib/trmnl/i18n/locales/web_ui/sk.yml
@@ -326,6 +326,7 @@ sk:
       tagline: Your TRMNL devices
       add_device_modal_title: Add a new device
       add_first_device: Start by adding your first device!
+      go_to_settings: Go to settings
     new:
       title: Add a new device
       description: Enter your Friendly ID to add a new device to your account.
@@ -351,6 +352,7 @@ sk:
     switch:
       error: Error switching device
       success: Device switched successfully
+      title: Switch to device
     update:
       error: Error updating device
       success: "%{device} device settings updated successfully"

--- a/lib/trmnl/i18n/locales/web_ui/sv.yml
+++ b/lib/trmnl/i18n/locales/web_ui/sv.yml
@@ -315,6 +315,7 @@ sv:
       tagline: Your TRMNL devices
       add_device_modal_title: Add a new device
       add_first_device: Start by adding your first device!
+      go_to_settings: Go to settings
     new:
       title: Add a new device
       description: Enter your Friendly ID to add a new device to your account.
@@ -340,6 +341,7 @@ sv:
     switch:
       error: Error switching device
       success: Device switched successfully
+      title: Switch to device
     update:
       error: Error updating device
       success: "%{device} device settings updated successfully"

--- a/lib/trmnl/i18n/locales/web_ui/uk.yml
+++ b/lib/trmnl/i18n/locales/web_ui/uk.yml
@@ -337,6 +337,7 @@ uk:
       tagline: Ваші пристрої TRMNL
       add_device_modal_title: Додати новий пристрій
       add_first_device: Почніть, додавши свій перший пристрій!
+      go_to_settings: Go to settings
     new:
       title: Додати новий пристрій
       description: Введіть ваш Дружній ID, щоб додати новий пристрій TRMNL до вашого акаунту.
@@ -362,6 +363,7 @@ uk:
     switch:
       error: Помилка перемикання пристрою
       success: Пристрій успішно перемкнено
+      title: Switch to device
     update:
       error: Помилка оновлення пристрою
       success: Налаштування пристрою %{device} успішно оновлено

--- a/lib/trmnl/i18n/locales/web_ui/zh-CN.yml
+++ b/lib/trmnl/i18n/locales/web_ui/zh-CN.yml
@@ -350,6 +350,7 @@ zh-CN:
       tagline: 您的的TRMNL设备
       add_device_modal_title: 添加新TRMNL设备
       add_first_device: 添加您的第一个TRMNL设备！
+      go_to_settings: Go to settings
     new:
       title: 添加新TRMNL设备
       description: 输入您的TRMNL设备ID以添加新TRMNL设备
@@ -375,6 +376,7 @@ zh-CN:
     switch:
       error: 禁止切换设备
       success: 设备切换成功
+      title: Switch to device
     update:
       error: 设备更新错误
       success: "“%{device} 更新成功”"

--- a/lib/trmnl/i18n/locales/web_ui/zh-HK.yml
+++ b/lib/trmnl/i18n/locales/web_ui/zh-HK.yml
@@ -315,6 +315,7 @@ zh-HK:
       tagline: 你的TRMNL裝置
       add_device_modal_title: 新增裝置
       add_first_device: 請先新增你的第一部裝置！
+      go_to_settings: Go to settings
     new:
       title: 新增裝置
       description: 輸入Friendly ID以新增裝置到你的帳戶。
@@ -340,6 +341,7 @@ zh-HK:
     switch:
       error: 切換裝置時發生錯誤
       success: 成功切換裝置
+      title: Switch to device
     update:
       error: 更新裝置時發生錯誤
       success: 成功更新「%{device}」的裝置設定


### PR DESCRIPTION
Companion PR for https://github.com/usetrmnl/core/pull/2866, which adds UX improvements to the /devices page. Adds `devices.index.go_to_settings` → "Go to settings"   and  `devices.switch.title` → "Switch to device".
                                                 