### PR TITLE
Pin rubocop-capybara to 2.22.0 to fix incompatibility with caliber 0.90

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gemspec
 group :quality do
   gem "caliber", "~> 0.68"
   gem "reek", "~> 6.4", require: false
+  gem "rubocop-capybara", "~> 2.22.0", require: false
   gem "simplecov", "~> 0.22", require: false
 end
 


### PR DESCRIPTION
Trying to fix the CircleCI failure seen in #252.
 
I found that rubocop-capybara beyond v2.22.0 is incompatible with caliber v0.90.0