### PR TITLE
Improved and added missing German translations + replace e-ink with ePaper across all locales

### DIFF
--- a/lib/trmnl/i18n/locales/plugin_renders/de-AT.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/de-AT.yml
@@ -4,8 +4,8 @@ de-AT:
     and_x_more_prefix: und
     and_x_more_suffix: weitere
     calendars:
-      no_upcoming_events: No upcoming events
-      no_events_today: No events today
+      no_upcoming_events: Keine bevorstehenden Ereignisse
+      no_events_today: Heute keine Ereignisse
     days_left_year:
       title: Verbleibende Tage dieses Jahr
       days_passed: Vergangene Tage
@@ -110,25 +110,25 @@ de-AT:
       right_now: jetzt
       today: heute
       tomorrow: morgen
-      low_high_short: L/H
+      low_high_short: Min/Max
       uv_short: UV
       max: Max
       tempest:
         conditions:
-          clear: Clear
-          cloudy: Cloudy
-          foggy: Foggy
-          partly_cloudy: Partly Cloudy
-          rain_likely: Rain Likely
-          rain_possible: Rain Possible
-          snow: Snow
-          snow_possible: Snow Possible
-          thunderstorms_likely: Thunderstorms Likely
-          thunderstorms_possible: Thunderstorms Possible
-          very_light_rain: Very Light Rain
-          windy: Windy
-          wintry_mix_likely: Wintry Mix Likely
-          wintry_mix_possible: Wintry Mix Possible
+          clear: Klar
+          cloudy: Bewölkt
+          foggy: Neblig
+          partly_cloudy: Teilweise bewölkt
+          rain_likely: Regen wahrscheinlich
+          rain_possible: Regen möglich
+          snow: Schnee
+          snow_possible: Schnee möglich
+          thunderstorms_likely: Gewitter wahrscheinlich
+          thunderstorms_possible: Gewitter möglich
+          very_light_rain: Sehr leichter Regen
+          windy: Windig
+          wintry_mix_likely: Winterlicher Mix wahrscheinlich
+          wintry_mix_possible: Winterlicher Mix möglich
       weatherapi:
         uv:
           low: niedrig

--- a/lib/trmnl/i18n/locales/plugin_renders/de.yml
+++ b/lib/trmnl/i18n/locales/plugin_renders/de.yml
@@ -4,8 +4,8 @@ de:
     and_x_more_prefix: und
     and_x_more_suffix: weitere
     calendars:
-      no_upcoming_events: No upcoming events
-      no_events_today: No events today
+      no_upcoming_events: Keine bevorstehenden Ereignisse
+      no_events_today: Heute keine Ereignisse
     days_left_year:
       title: Verbleibende Tage dieses Jahr
       days_passed: Vergangene Tage

--- a/lib/trmnl/i18n/locales/web_ui/da.yml
+++ b/lib/trmnl/i18n/locales/web_ui/da.yml
@@ -249,7 +249,7 @@ da:
       firmware_updates_enabled: Updates enabled
       firmware_updates_disabled: Updates disabled
       font_family: Font Family
-      font_family_hint: The TRMNL font family was designed for optimal performance on e-ink screens. Supported on plugins with UI Framework v%{min_version}+.
+      font_family_hint: The TRMNL font family was designed for optimal performance on ePaper screens. Supported on plugins with UI Framework v%{min_version}+.
       guest_mode: Gæstetilstand
       guest_mode_hint: Vælg hvad der skal vises (og i hvor lang tid), når gæstetilstand er aktiveret.
       guest_mode_item_placeholder: Vælg et element
@@ -272,12 +272,12 @@ da:
       ota_enabled_hint: Installer automatisk ny firmware. Deaktiver for at bruge din egen firmware.
       ota_byod_not_supported: OTA understøttes ikke for BYOD-enheder. Flash en kompatibel version direkte fra trmnl.com/flash
       maximum_compatibility: Aktivér maksimal kompatibilitet
-      maximum_compatibility_hint: Løser visningsproblemer forårsaget af visse e-ink driverchips. Deaktiverer hurtig opdatering. Firmware 1.6.0+ kræves.
+      maximum_compatibility_hint: Løser visningsproblemer forårsaget af visse ePaper driverchips. Deaktiverer hurtig opdatering. Firmware 1.6.0+ kræves.
       color_and_rotation: Farve og rotation
       screen_rotation: Skærmrotation
       screen_rotation_not_supported: Skærmrotation er ikke understøttet på din enhed.
       palette: Color Palette
-      palette_hint: Select the set of colors to use when generating screens for this device. A larger palette looks nicer, but a smaller palette draws faster on e-ink. Individual playlist items can override this setting.
+      palette_hint: Select the set of colors to use when generating screens for this device. A larger palette looks nicer, but a smaller palette draws faster on ePaper. Individual playlist items can override this setting.
       presentation: Presentation
       sleep_mode: Dvaletilstand
       sleep_mode_hint: Juster opdateringshastigheden for at optimere fokus og batterilevetid.

--- a/lib/trmnl/i18n/locales/web_ui/de-AT.yml
+++ b/lib/trmnl/i18n/locales/web_ui/de-AT.yml
@@ -5,7 +5,7 @@ de-AT:
   add: Hinzufügen
   add_new: Neu hinzufügen
   ai_assistant: Agent
-  ai_assistant_hint: Enable the Agent for markup editing in the plugin editor.
+  ai_assistant_hint: Aktiviere den Agent für die Markup-Bearbeitung im Plugin-Editor.
   already_have_account: Ich besitze bereits ein Konto
   are_you_sure: Bist du sicher?
   back: Zurück
@@ -34,7 +34,7 @@ de-AT:
   developer_edition_required: Die TRMNL-Entwickler-Edition wird für dieses Feature benötigt.
   device_id: Gerätekennung
   device: Gerät
-  discard: Discard
+  discard: Verwerfen
   edit: Ändern
   email_address: E-Mail-Adresse
   export: Exportieren
@@ -66,7 +66,7 @@ de-AT:
   plugin_not_found: Erweiterung nicht gefunden
   preview: Vorschau
   privacy: Datenschutz
-  refresh_rate: Refresh rate
+  refresh_rate: Aktualisierungsrate
   refresh_rates_hint: Weitere Informationen zur Aktualisierungsrate __hier__.
   reset_password: Passwort zurücksetzen
   reset_to_defaults: Auf Standard zurücksetzen
@@ -82,7 +82,7 @@ de-AT:
   subscribe: Abonnieren
   help_center: Hilfe
   terms: AGB
-  unsaved_changes: You have unsaved changes
+  unsaved_changes: Du hast ungespeicherte Änderungen
   update: Aktualisieren
   view: Ansicht
   collaboration_request: Lust zusammenzuarbeiten?
@@ -171,7 +171,7 @@ de-AT:
       session_hint: Angemeldet als %{user}
       show_title_bar: Titelleiste anzeigen
       show_title_bar_hint: Bei ausgeschalteter Option werden (nicht-globale) offizielle und Community-Erweiterungen minimalistischer aussehen.
-      theme_hint: Personalize TRMNL's interface by setting a theme or syncing to your device.
+      theme_hint: Personalisiere die TRMNL-Oberfläche durch Auswahl eines Themes oder Synchronisierung mit deinem Gerät.
       time_zone: Zeitzone
       time_zone_hint: Legt Aktualisierungsraten und Ruhezeiten des Geräts fest.
       locale: Sprache
@@ -233,11 +233,11 @@ de-AT:
       device_model: Gerätemodell
       device_model_hint: Dein Hardware-Modell
       device_model_switch_warning: Diese Aktion kann gefährlich sein, erfahre __hier__ mehr darüber
-      device_info: Device Info
-      current_firmware: Current firmware
-      last_ping: Last ping
-      unknown: Unknown
-      never: Never
+      device_info: Geräteinformationen
+      current_firmware: Aktuelle Firmware
+      last_ping: Letzter Ping
+      unknown: Unbekannt
+      never: Nie
       display_calibration: Bildschirmkalibrierung
       display_calibration_hint: Rendering deines Displays anpassen. Feld leer lassen, um die Standardwerte zu verwenden.
       display_calibration_pixel_ratio: Pixelverhältnis
@@ -248,8 +248,8 @@ de-AT:
       firmware: Firmware
       firmware_updates_enabled: Updates aktiviert
       firmware_updates_disabled: Updates deaktiviert
-      font_family: Font Family
-      font_family_hint: The TRMNL font family was designed for optimal performance on ePaper screens. Supported on plugins with UI Framework v%{min_version}+.
+      font_family: Schriftfamilie
+      font_family_hint: Die TRMNL-Schriftfamilie wurde für optimale Lesbarkeit auf ePaper-Bildschirmen entwickelt. Unterstützt von Erweiterungen mit UI Framework v%{min_version}+.
       guest_mode: Gästemodus
       guest_mode_hint: Was soll angezeigt werden (und wie lange), wenn der Gästemodus eingeschaltet wurde.
       guest_mode_item_placeholder: Eintrag auswählen
@@ -278,7 +278,7 @@ de-AT:
       screen_rotation_not_supported: Bildschirmrotation ist derzeit nicht auf deinem Gerät unterstützt.
       palette: Farbpalette
       palette_hint: Wähle die Farbzahl für die Anzeige auf diesem Gerät. Große Paletten wirken schöner, kleine Paletten werden auf ePaper schneller angezeigt. Einzelne Einträge in der Wiedergabeliste können diese Einstellung überschreiben.
-      presentation: Presentation
+      presentation: Darstellung
       sleep_mode: Schlafmodus
       sleep_mode_hint: Aktualisierungsrate für bessere Konzentration und Batterielaufzeit anpassen.
       sleep_screen: Schlaf-Bildschirm
@@ -289,15 +289,15 @@ de-AT:
       special_function_learn_more: Erfahre mehr zu den Sonderfunktionen __hier__.
       temperature_profile: Temperaturprofil
       temperature_profile_hint: Nur ändern, wenn du dazu aufgefordert wirst. Für Displays mit zu blasser Darstellung.
-      touchbar_mode: Touchbar Mode
-      touchbar_mode_hint: What type of gestures should your device respond to?
+      touchbar_mode: Touchbar-Modus
+      touchbar_mode_hint: Auf welche Art von Gesten soll dein Gerät reagieren?
       tidbyt_credentials: Tidbyt-Anmeldedaten
       tidbyt_credentials_hint: Gib hier die API-Zugangsdaten deines Tidbyt-Geräts ein (Einstellungen → Entwickler → API-Schlüssel in der Tidbyt-App).
       tidbyt_credentials_invalid: Ungültige Tidbyt-API-Zugangsdaten. Bitte prüfen und erneut versuchen.
       tidbyt_device_id: Geräte-ID
       tidbyt_device_api_key: API-Schlüssel
       unlink: Entkoppeln
-      unlink_confirm: Are you sure? Only proceed if you are giving this device to someone else or switching to BYOS. Unpairing deletes all plugin settings and playlist items. If troubleshooting, contact support at help.trmnl.com.
+      unlink_confirm: Bist du sicher? Fahre nur fort, wenn du das Gerät an jemand anderen weitergibst oder zu BYOS wechselst. Das Trennen löscht alle Erweiterungseinstellungen und Wiedergabelisteneinträge. Bei Problemen wende dich an den Support unter help.trmnl.com.
       unlink_device: Gerät entkoppeln
       unlink_device_hint: Verbindung zu einem TRMNL-Gerät entfernen, um es sicher zu verkaufen oder weiterzugeben.
       unlink_device_learn_more: __Hier__ gibt es die vollständige Anleitung dazu.
@@ -436,17 +436,17 @@ de-AT:
       remove_from_playlist: Von Wiedergabeliste entfernen
       hide_playlist: Eintrag verstecken
       show_playlist: Eintrag anzeigen
-      duplicate: Duplicate
-      duplicate_confirm: This will create a copy of this item and add it to the bottom of your playlist. Continue?
-      color_palette: Color Palette
-      device_default: Device Default (%{name})
-      palette_unavailable: Only available for devices with multiple color palettes
+      duplicate: Duplizieren
+      duplicate_confirm: Es wird eine Kopie dieses Eintrags erstellt und am Ende der Wiedergabeliste hinzugefügt. Fortfahren?
+      color_palette: Farbpalette
+      device_default: Geräte-Standard (%{name})
+      palette_unavailable: Nur verfügbar für Geräte mit mehreren Farbpaletten
       refresh_rate_disabled:
-        default: This plugin's refresh rate cannot be configured.
-        external: This plugin fetches data on the fly, so refresh rate settings don't apply.
-        global: This plugin gets refreshed platform-wide on a fixed schedule.
-        mashup: The mashup will refresh as often as its fastest plugin.
-        readonly: This plugin has a fixed refresh rate that cannot be configured.
+        default: Die Aktualisierungsrate dieser Erweiterung kann nicht konfiguriert werden.
+        external: Diese Erweiterung ruft Daten in Echtzeit ab, daher gelten keine Aktualisierungsraten-Einstellungen.
+        global: Diese Erweiterung wird plattformweit nach einem festen Zeitplan aktualisiert.
+        mashup: Das Mashup wird so oft aktualisiert wie seine schnellste Erweiterung.
+        readonly: Diese Erweiterung hat eine feste Aktualisierungsrate, die nicht konfiguriert werden kann.
     create:
       error: Fehler beim Aktualisieren der Wiedergabeliste
       success: Wiedergabeliste aktualisiert
@@ -522,15 +522,15 @@ de-AT:
     new:
       error: Blaupause nicht gefunden
     show:
-      more_by_author: More by this Author
-      view_all: View all
+      more_by_author: Mehr von diesem Autor
+      view_all: Alle anzeigen
   plugin_settings:
     active: Aktiv
     copy_are_you_sure: Möchtest du diese Einstellung wirklich kopieren?
     delete_are_you_sure: Möchtest du diese Einstellung wirklich löschen?
     delete: Hiermit werden alle Einstellungen der Erweiterung vollständig entfernt. Um sie lediglich auszublenden, entferne sie von der Wiedergabeliste.
     inactive: Inaktiv
-    no_matches_found: No plugins match your filters.
+    no_matches_found: Keine Erweiterungen entsprechen deinen Filtern.
     no_plugin_settings_found: Keine Einstellungen für diese Erweiterung gefunden.
     not_supported: Aktuell für dieses Gerät nicht unterstützt
     refreshing_now_please_wait: Wird aktualisiert, bitte die Seite in ein paar Sekunden neu laden.

--- a/lib/trmnl/i18n/locales/web_ui/de-AT.yml
+++ b/lib/trmnl/i18n/locales/web_ui/de-AT.yml
@@ -249,7 +249,7 @@ de-AT:
       firmware_updates_enabled: Updates aktiviert
       firmware_updates_disabled: Updates deaktiviert
       font_family: Font Family
-      font_family_hint: The TRMNL font family was designed for optimal performance on e-ink screens. Supported on plugins with UI Framework v%{min_version}+.
+      font_family_hint: The TRMNL font family was designed for optimal performance on ePaper screens. Supported on plugins with UI Framework v%{min_version}+.
       guest_mode: Gästemodus
       guest_mode_hint: Was soll angezeigt werden (und wie lange), wenn der Gästemodus eingeschaltet wurde.
       guest_mode_item_placeholder: Eintrag auswählen
@@ -272,12 +272,12 @@ de-AT:
       ota_enabled_hint: Neue Firmware automatisch installieren. Deaktiviere diese Option, um deine eigene Firmware zu verwenden.
       ota_byod_not_supported: OTA wird für BYOD-Geräte nicht unterstützt. Überspiele eine kompatible Version direkt unter trmnl.com/flash.
       maximum_compatibility: Maximale Kompatibilität aktivieren
-      maximum_compatibility_hint: Behebt Anzeigefehler aufgrund bestimmter E-Ink-Treiber-Chips. Deaktiviert schnelles Rendern. Benötigt Firmware 1.6.0+.
+      maximum_compatibility_hint: Behebt Anzeigefehler aufgrund bestimmter ePaper-Treiber-Chips. Deaktiviert schnelles Rendern. Benötigt Firmware 1.6.0+.
       color_and_rotation: Farbe & Rotation
       screen_rotation: Bildschirmrotation
       screen_rotation_not_supported: Bildschirmrotation ist derzeit nicht auf deinem Gerät unterstützt.
       palette: Farbpalette
-      palette_hint: Wähle die Farbzahl für die Anzeige auf diesem Gerät. Große Paletten wirken schöner, kleine Paletten werden auf E-Ink schneller angezeigt. Einzelne Einträge in der Wiedergabeliste können diese Einstellung überschreiben.
+      palette_hint: Wähle die Farbzahl für die Anzeige auf diesem Gerät. Große Paletten wirken schöner, kleine Paletten werden auf ePaper schneller angezeigt. Einzelne Einträge in der Wiedergabeliste können diese Einstellung überschreiben.
       presentation: Presentation
       sleep_mode: Schlafmodus
       sleep_mode_hint: Aktualisierungsrate für bessere Konzentration und Batterielaufzeit anpassen.

--- a/lib/trmnl/i18n/locales/web_ui/de.yml
+++ b/lib/trmnl/i18n/locales/web_ui/de.yml
@@ -5,7 +5,7 @@ de:
   add: Hinzufügen
   add_new: Neu hinzufügen
   ai_assistant: Agent
-  ai_assistant_hint: Enable the Agent for markup editing in the plugin editor.
+  ai_assistant_hint: Aktiviere den Agent für die Markup-Bearbeitung im Plugin-Editor.
   already_have_account: Ich besitze bereits ein Konto
   are_you_sure: Bist du sicher?
   back: Zurück
@@ -34,7 +34,7 @@ de:
   developer_edition_required: Die TRMNL-Entwickler-Edition wird für dieses Feature benötigt.
   device_id: Gerätekennung
   device: Gerät
-  discard: Discard
+  discard: Verwerfen
   edit: Ändern
   email_address: E-Mail-Adresse
   export: Exportieren
@@ -66,7 +66,7 @@ de:
   plugin_not_found: Erweiterung nicht gefunden
   preview: Vorschau
   privacy: Datenschutz
-  refresh_rate: Refresh rate
+  refresh_rate: Aktualisierungsrate
   refresh_rates_hint: Weitere Informationen zur Aktualisierungsrate __hier__.
   reset_password: Passwort zurücksetzen
   reset_to_defaults: Auf Standard zurücksetzen
@@ -82,7 +82,7 @@ de:
   subscribe: Abonnieren
   help_center: Hilfe
   terms: AGB
-  unsaved_changes: You have unsaved changes
+  unsaved_changes: Du hast ungespeicherte Änderungen
   update: Aktualisieren
   view: Ansicht
   collaboration_request: Lust zusammenzuarbeiten?
@@ -171,7 +171,7 @@ de:
       session_hint: Angemeldet als %{user}
       show_title_bar: Titelleiste anzeigen
       show_title_bar_hint: Bei ausgeschalteter Option werden (nicht-globale) offizielle und Community-Erweiterungen minimalistischer aussehen.
-      theme_hint: Personalize TRMNL's interface by setting a theme or syncing to your device.
+      theme_hint: Personalisiere die TRMNL-Oberfläche durch Auswahl eines Themes oder Synchronisierung mit deinem Gerät.
       time_zone: Zeitzone
       time_zone_hint: Legt Aktualisierungsraten und Ruhezeiten des Geräts fest.
       locale: Sprache
@@ -233,11 +233,11 @@ de:
       device_model: Gerätemodell
       device_model_hint: Dein Hardware-Modell
       device_model_switch_warning: Diese Aktion kann gefährlich sein, erfahre __hier__ mehr darüber
-      device_info: Device Info
-      current_firmware: Current firmware
-      last_ping: Last ping
-      unknown: Unknown
-      never: Never
+      device_info: Geräteinformationen
+      current_firmware: Aktuelle Firmware
+      last_ping: Letzter Ping
+      unknown: Unbekannt
+      never: Nie
       display_calibration: Bildschirmkalibrierung
       display_calibration_hint: Rendering deines Displays anpassen. Feld leer lassen, um die Standardwerte zu verwenden.
       display_calibration_pixel_ratio: Pixelverhältnis
@@ -248,8 +248,8 @@ de:
       firmware: Firmware
       firmware_updates_enabled: Updates aktiviert
       firmware_updates_disabled: Updates deaktiviert
-      font_family: Font Family
-      font_family_hint: The TRMNL font family was designed for optimal performance on e-ink screens. Supported on plugins with UI Framework v%{min_version}+.
+      font_family: Schriftfamilie
+      font_family_hint: Die TRMNL-Schriftfamilie wurde für optimale Lesbarkeit auf ePaper-Bildschirmen entwickelt. Unterstützt von Erweiterungen mit UI Framework v%{min_version}+.
       guest_mode: Gästemodus
       guest_mode_hint: Was soll angezeigt werden (und wie lange), wenn der Gästemodus eingeschaltet wurde.
       guest_mode_item_placeholder: Eintrag auswählen
@@ -272,13 +272,13 @@ de:
       ota_enabled_hint: Neue Firmware automatisch installieren. Deaktiviere diese Option, um deine eigene Firmware zu verwenden.
       ota_byod_not_supported: OTA wird für BYOD-Geräte nicht unterstützt. Überspiele eine kompatible Version direkt unter trmnl.com/flash.
       maximum_compatibility: Maximale Kompatibilität aktivieren
-      maximum_compatibility_hint: Behebt Anzeigefehler aufgrund bestimmter E-Ink-Treiber-Chips. Deaktiviert schnelles Rendern. Benötigt Firmware 1.6.0+.
+      maximum_compatibility_hint: Behebt Anzeigefehler aufgrund bestimmter ePaper-Treiber-Chips. Deaktiviert schnelles Rendern. Benötigt Firmware 1.6.0+.
       color_and_rotation: Farbe & Rotation
       screen_rotation: Bildschirmrotation
       screen_rotation_not_supported: Bildschirmrotation ist derzeit nicht auf deinem Gerät unterstützt.
       palette: Farbpalette
-      palette_hint: Wähle die Farbzahl für die Anzeige auf diesem Gerät. Große Paletten wirken schöner, kleine Paletten werden auf E-Ink schneller angezeigt. Einzelne Einträge in der Wiedergabeliste können diese Einstellung überschreiben.
-      presentation: Presentation
+      palette_hint: Wähle die Farbzahl für die Anzeige auf diesem Gerät. Große Paletten wirken schöner, kleine Paletten werden auf ePaper schneller angezeigt. Einzelne Einträge in der Wiedergabeliste können diese Einstellung überschreiben.
+      presentation: Darstellung
       sleep_mode: Schlafmodus
       sleep_mode_hint: Aktualisierungsrate für bessere Konzentration und Batterielaufzeit anpassen.
       sleep_screen: Schlaf-Bildschirm
@@ -289,15 +289,15 @@ de:
       special_function_learn_more: Erfahre mehr zu den Sonderfunktionen __hier__.
       temperature_profile: Temperaturprofil
       temperature_profile_hint: Nur ändern, wenn du dazu aufgefordert wirst. Für Displays mit zu blasser Darstellung.
-      touchbar_mode: Touchbar Mode
-      touchbar_mode_hint: What type of gestures should your device respond to?
+      touchbar_mode: Touchbar-Modus
+      touchbar_mode_hint: Auf welche Art von Gesten soll dein Gerät reagieren?
       tidbyt_credentials: Tidbyt-Anmeldedaten
       tidbyt_credentials_hint: Gib hier die API-Zugangsdaten deines Tidbyt-Geräts ein (Einstellungen → Entwickler → API-Schlüssel in der Tidbyt-App).
       tidbyt_credentials_invalid: Ungültige Tidbyt-API-Zugangsdaten. Bitte prüfen und erneut versuchen.
       tidbyt_device_id: Geräte-ID
       tidbyt_device_api_key: API-Schlüssel
       unlink: Entkoppeln
-      unlink_confirm: Are you sure? Only proceed if you are giving this device to someone else or switching to BYOS. Unpairing deletes all plugin settings and playlist items. If troubleshooting, contact support at help.trmnl.com.
+      unlink_confirm: Bist du sicher? Fahre nur fort, wenn du das Gerät an jemand anderen weitergibst oder zu BYOS wechselst. Das Trennen löscht alle Erweiterungseinstellungen und Wiedergabelisteneinträge. Bei Problemen wende dich an den Support unter help.trmnl.com.
       unlink_device: Gerät entkoppeln
       unlink_device_hint: Verbindung zu einem TRMNL-Gerät entfernen, um es sicher zu verkaufen oder weiterzugeben.
       unlink_device_learn_more: __Hier__ gibt es die vollständige Anleitung dazu.
@@ -436,17 +436,17 @@ de:
       remove_from_playlist: Von Wiedergabeliste entfernen
       hide_playlist: Eintrag verstecken
       show_playlist: Eintrag anzeigen
-      duplicate: Duplicate
-      duplicate_confirm: This will create a copy of this item and add it to the bottom of your playlist. Continue?
-      color_palette: Color Palette
-      device_default: Device Default (%{name})
-      palette_unavailable: Only available for devices with multiple color palettes
+      duplicate: Duplizieren
+      duplicate_confirm: Es wird eine Kopie dieses Eintrags erstellt und am Ende der Wiedergabeliste hinzugefügt. Fortfahren?
+      color_palette: Farbpalette
+      device_default: Geräte-Standard (%{name})
+      palette_unavailable: Nur verfügbar für Geräte mit mehreren Farbpaletten
       refresh_rate_disabled:
-        default: This plugin's refresh rate cannot be configured.
-        external: This plugin fetches data on the fly, so refresh rate settings don't apply.
-        global: This plugin gets refreshed platform-wide on a fixed schedule.
-        mashup: The mashup will refresh as often as its fastest plugin.
-        readonly: This plugin has a fixed refresh rate that cannot be configured.
+        default: Die Aktualisierungsrate dieser Erweiterung kann nicht konfiguriert werden.
+        external: Diese Erweiterung ruft Daten in Echtzeit ab, daher gelten keine Aktualisierungsraten-Einstellungen.
+        global: Diese Erweiterung wird plattformweit nach einem festen Zeitplan aktualisiert.
+        mashup: Das Mashup wird so oft aktualisiert wie seine schnellste Erweiterung.
+        readonly: Diese Erweiterung hat eine feste Aktualisierungsrate, die nicht konfiguriert werden kann.
     create:
       error: Fehler beim Aktualisieren der Wiedergabeliste
       success: Wiedergabeliste aktualisiert
@@ -522,15 +522,15 @@ de:
     new:
       error: Blaupause nicht gefunden
     show:
-      more_by_author: More by this Author
-      view_all: View all
+      more_by_author: Mehr von diesem Autor
+      view_all: Alle anzeigen
   plugin_settings:
     active: Aktiv
     copy_are_you_sure: Möchtest du diese Einstellung wirklich kopieren?
     delete_are_you_sure: Möchtest du diese Einstellung wirklich löschen?
     delete: Hiermit werden alle Einstellungen der Erweiterung vollständig entfernt. Um sie lediglich auszublenden, entferne sie von der Wiedergabeliste.
     inactive: Inaktiv
-    no_matches_found: No plugins match your filters.
+    no_matches_found: Keine Erweiterungen entsprechen deinen Filtern.
     no_plugin_settings_found: Keine Einstellungen für diese Erweiterung gefunden.
     not_supported: Aktuell für dieses Gerät nicht unterstützt
     refreshing_now_please_wait: Wird aktualisiert, bitte die Seite in ein paar Sekunden neu laden.

--- a/lib/trmnl/i18n/locales/web_ui/en-GB.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en-GB.yml
@@ -249,7 +249,7 @@ en-GB:
       firmware_updates_enabled: Updates enabled
       firmware_updates_disabled: Updates disabled
       font_family: Font Family
-      font_family_hint: The TRMNL font family was designed for optimal performance on e-ink screens. Supported on plugins with UI Framework v%{min_version}+.
+      font_family_hint: The TRMNL font family was designed for optimal performance on ePaper screens. Supported on plugins with UI Framework v%{min_version}+.
       guest_mode: Guest Mode
       guest_mode_hint: Choose what to display (and for how long) whenever guest mode is enabled.
       guest_mode_item_placeholder: Choose an item
@@ -272,12 +272,12 @@ en-GB:
       ota_enabled_hint: Automatically install new firmware. Disable to use your own firmware.
       ota_byod_not_supported: OTA is not supported for BYOD devices. Flash a compatible version directly from trmnl.com/flash
       maximum_compatibility: Enable Maximum Compatibility
-      maximum_compatibility_hint: Resolves display issues caused by certain e-ink driver chips. Disables fast refresh. Firmware 1.6.0+ required.
+      maximum_compatibility_hint: Resolves display issues caused by certain ePaper driver chips. Disables fast refresh. Firmware 1.6.0+ required.
       color_and_rotation: Colour & Rotation
       screen_rotation: Screen Rotation
       screen_rotation_not_supported: Screen rotation is currently not supported on your device.
       palette: Colour Palette
-      palette_hint: Select the set of colours to use when generating screens for this device. A larger palette looks nicer, but a smaller palette draws faster on e-ink. Individual playlist items can override this setting.
+      palette_hint: Select the set of colours to use when generating screens for this device. A larger palette looks nicer, but a smaller palette draws faster on ePaper. Individual playlist items can override this setting.
       presentation: Presentation
       sleep_mode: Sleep Mode
       sleep_mode_hint: Adjust your refresh rate to optimize focus and battery life.

--- a/lib/trmnl/i18n/locales/web_ui/en.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en.yml
@@ -249,7 +249,7 @@ en:
       firmware_updates_enabled: Updates enabled
       firmware_updates_disabled: Updates disabled
       font_family: Font Family
-      font_family_hint: The TRMNL font family was designed for optimal performance on e-ink screens. Supported on plugins with UI Framework v%{min_version}+.
+      font_family_hint: The TRMNL font family was designed for optimal performance on ePaper screens. Supported on plugins with UI Framework v%{min_version}+.
       guest_mode: Guest Mode
       guest_mode_hint: Choose what to display (and for how long) whenever guest mode is enabled.
       guest_mode_item_placeholder: Choose an item
@@ -272,12 +272,12 @@ en:
       ota_enabled_hint: Automatically install new firmware. Disable to use your own firmware.
       ota_byod_not_supported: OTA is not supported for BYOD devices. Flash a compatible version directly from trmnl.com/flash
       maximum_compatibility: Enable Maximum Compatibility
-      maximum_compatibility_hint: Resolves display issues caused by certain e-ink driver chips. Disables fast refresh. Firmware 1.6.0+ required.
+      maximum_compatibility_hint: Resolves display issues caused by certain ePaper driver chips. Disables fast refresh. Firmware 1.6.0+ required.
       color_and_rotation: Color & Rotation
       screen_rotation: Screen Rotation
       screen_rotation_not_supported: Screen rotation is currently not supported on your device.
       palette: Color Palette
-      palette_hint: Select the set of colors to use when generating screens for this device. A larger palette looks nicer, but a smaller palette draws faster on e-ink. Individual playlist items can override this setting.
+      palette_hint: Select the set of colors to use when generating screens for this device. A larger palette looks nicer, but a smaller palette draws faster on ePaper. Individual playlist items can override this setting.
       presentation: Presentation
       sleep_mode: Sleep Mode
       sleep_mode_hint: Adjust your refresh rate to optimize focus and battery life.

--- a/lib/trmnl/i18n/locales/web_ui/es-ES.yml
+++ b/lib/trmnl/i18n/locales/web_ui/es-ES.yml
@@ -249,7 +249,7 @@ es-ES:
       firmware_updates_enabled: Actualizaciones habilitadas
       firmware_updates_disabled: Actualizaciones deshabilitadas
       font_family: Font Family
-      font_family_hint: The TRMNL font family was designed for optimal performance on e-ink screens. Supported on plugins with UI Framework v%{min_version}+.
+      font_family_hint: The TRMNL font family was designed for optimal performance on ePaper screens. Supported on plugins with UI Framework v%{min_version}+.
       guest_mode: Modo invitado
       guest_mode_hint: Elige qué mostrar (y por cuánto tiempo) cuando el modo invitado esté activado.
       guest_mode_item_placeholder: Elige un elemento
@@ -277,7 +277,7 @@ es-ES:
       screen_rotation: Rotación de pantalla
       screen_rotation_not_supported: La rotación de pantalla no está actualmente soportada en tu dispositivo.
       palette: Paleta de colores
-      palette_hint: Selecciona la paleta de colores para las pantallas de este dispositivo. Una paleta mayor se ve mejor, pero una menor dibuja más rápido en e-ink. Los elementos de la lista pueden anular esto.
+      palette_hint: Selecciona la paleta de colores para las pantallas de este dispositivo. Una paleta mayor se ve mejor, pero una menor dibuja más rápido en ePaper. Los elementos de la lista pueden anular esto.
       presentation: Presentation
       sleep_mode: Modo de suspensión
       sleep_mode_hint: Ajusta tu tasa de refresco para optimizar el enfoque y la duración de la batería.

--- a/lib/trmnl/i18n/locales/web_ui/fr.yml
+++ b/lib/trmnl/i18n/locales/web_ui/fr.yml
@@ -251,7 +251,7 @@ fr:
       firmware_updates_enabled: Mises à jour activées
       firmware_updates_disabled: Mises à jour désactivées
       font_family: Font Family
-      font_family_hint: The TRMNL font family was designed for optimal performance on e-ink screens. Supported on plugins with UI Framework v%{min_version}+.
+      font_family_hint: The TRMNL font family was designed for optimal performance on ePaper screens. Supported on plugins with UI Framework v%{min_version}+.
       guest_mode: Mode invité
       guest_mode_hint: Choisissez ce qui s'affiche (et pendant combien de temps) quand le mode invité est activé.
       guest_mode_item_placeholder: Choisir un élément
@@ -274,12 +274,12 @@ fr:
       ota_enabled_hint: Installe automatiquement le nouveau firmware. Désactivez cette option si vous souhaitez utiliser votre propre firmware.
       ota_byod_not_supported: L'OTA n'est pas pris en charge pour les appareils BYOD. Flashez une version compatible directement depuis trmnl.com/flash
       maximum_compatibility: Activer la compatibilité maximale
-      maximum_compatibility_hint: Résout les problèmes d'affichage causés par certaines puces de pilote e-ink. Désactive le rafraîchissement rapide. Firmware 1.6.0+ requis.
+      maximum_compatibility_hint: Résout les problèmes d'affichage causés par certaines puces de pilote ePaper. Désactive le rafraîchissement rapide. Firmware 1.6.0+ requis.
       color_and_rotation: Couleur & Rotation
       screen_rotation: Rotation de l'écran
       screen_rotation_not_supported: La rotation de l'écran n'est pas actuellement prise en charge sur votre appareil.
       palette: Color Palette
-      palette_hint: Select the set of colors to use when generating screens for this device. A larger palette looks nicer, but a smaller palette draws faster on e-ink. Individual playlist items can override this setting.
+      palette_hint: Select the set of colors to use when generating screens for this device. A larger palette looks nicer, but a smaller palette draws faster on ePaper. Individual playlist items can override this setting.
       presentation: Presentation
       sleep_mode: Mode Veille
       sleep_mode_hint: Ajustez la fréquence de rafraîchissement pour réduire les distractions et augmenter l'autonomie de la batterie.

--- a/lib/trmnl/i18n/locales/web_ui/he.yml
+++ b/lib/trmnl/i18n/locales/web_ui/he.yml
@@ -251,7 +251,7 @@ he:
       firmware_updates_enabled: Updates enabled
       firmware_updates_disabled: Updates disabled
       font_family: Font Family
-      font_family_hint: The TRMNL font family was designed for optimal performance on e-ink screens. Supported on plugins with UI Framework v%{min_version}+.
+      font_family_hint: The TRMNL font family was designed for optimal performance on ePaper screens. Supported on plugins with UI Framework v%{min_version}+.
       guest_mode: Guest Mode
       guest_mode_hint: Choose what to display (and for how long) whenever guest mode is enabled.
       guest_mode_item_placeholder: Choose an item
@@ -274,12 +274,12 @@ he:
       ota_enabled_hint: Automatically install new firmware. Disable to use your own firmware.
       ota_byod_not_supported: OTA is not supported for BYOD devices. Flash a compatible version directly from trmnl.com/flash
       maximum_compatibility: Enable Maximum Compatibility
-      maximum_compatibility_hint: Resolves display issues caused by certain e-ink driver chips. Disables fast refresh. Firmware 1.6.0+ required.
+      maximum_compatibility_hint: Resolves display issues caused by certain ePaper driver chips. Disables fast refresh. Firmware 1.6.0+ required.
       color_and_rotation: Color & Rotation
       screen_rotation: Screen Rotation
       screen_rotation_not_supported: Screen rotation is currently not supported on your device.
       palette: Color Palette
-      palette_hint: Select the set of colors to use when generating screens for this device. A larger palette looks nicer, but a smaller palette draws faster on e-ink. Individual playlist items can override this setting.
+      palette_hint: Select the set of colors to use when generating screens for this device. A larger palette looks nicer, but a smaller palette draws faster on ePaper. Individual playlist items can override this setting.
       presentation: Presentation
       sleep_mode: Sleep Mode
       sleep_mode_hint: Adjust your refresh rate to optimize focus and battery life.

--- a/lib/trmnl/i18n/locales/web_ui/hu.yml
+++ b/lib/trmnl/i18n/locales/web_ui/hu.yml
@@ -249,7 +249,7 @@ hu:
       firmware_updates_enabled: Updates enabled
       firmware_updates_disabled: Updates disabled
       font_family: Font Family
-      font_family_hint: The TRMNL font family was designed for optimal performance on e-ink screens. Supported on plugins with UI Framework v%{min_version}+.
+      font_family_hint: The TRMNL font family was designed for optimal performance on ePaper screens. Supported on plugins with UI Framework v%{min_version}+.
       guest_mode: Vendég mód
       guest_mode_hint: Válaszd ki, mit (és mennyi ideig) jelenítsen meg az eszköz, amikor a vendég mód be van kapcsolva.
       guest_mode_item_placeholder: Válassz egy elemet
@@ -272,12 +272,12 @@ hu:
       ota_enabled_hint: Automatikusan telepíti az új firmware-t. Kapcsold ki, ha saját firmware-t szeretnél használni.
       ota_byod_not_supported: Az OTA nem támogatott a saját eszközök (BYOD) esetén. Tölts le egy kompatibilis verziót közvetlenül a trmnl.com/flash oldalról.
       maximum_compatibility: Maximális kompatibilitás engedélyezése
-      maximum_compatibility_hint: Kijavítja az egyes e-ink kijelzőchipek által okozott megjelenítési hibákat. Kikapcsolja a gyors frissítést. Firmware 1.6.0+ szükséges.
+      maximum_compatibility_hint: Kijavítja az egyes ePaper kijelzőchipek által okozott megjelenítési hibákat. Kikapcsolja a gyors frissítést. Firmware 1.6.0+ szükséges.
       color_and_rotation: Szín & forgatás
       screen_rotation: Képernyő forgatása
       screen_rotation_not_supported: A képernyő forgatása jelenleg nem támogatott a te eszközödön.
       palette: Color Palette
-      palette_hint: Select the set of colors to use when generating screens for this device. A larger palette looks nicer, but a smaller palette draws faster on e-ink. Individual playlist items can override this setting.
+      palette_hint: Select the set of colors to use when generating screens for this device. A larger palette looks nicer, but a smaller palette draws faster on ePaper. Individual playlist items can override this setting.
       presentation: Presentation
       sleep_mode: Alvó mód
       sleep_mode_hint: Állítsd be a frissítési rátát a fókusz és az akkumulátor-élettartam optimalizálásához.

--- a/lib/trmnl/i18n/locales/web_ui/id.yml
+++ b/lib/trmnl/i18n/locales/web_ui/id.yml
@@ -251,7 +251,7 @@ id:
       firmware_updates_enabled: Updates enabled
       firmware_updates_disabled: Updates disabled
       font_family: Font Family
-      font_family_hint: The TRMNL font family was designed for optimal performance on e-ink screens. Supported on plugins with UI Framework v%{min_version}+.
+      font_family_hint: The TRMNL font family was designed for optimal performance on ePaper screens. Supported on plugins with UI Framework v%{min_version}+.
       guest_mode: Guest Mode
       guest_mode_hint: Choose what to display (and for how long) whenever guest mode is enabled.
       guest_mode_item_placeholder: Choose an item
@@ -274,12 +274,12 @@ id:
       ota_enabled_hint: Firmware terbaru akan diinstal secara otomatis. Nonaktifkan jika menggunakan firmware Anda sendiri.
       ota_byod_not_supported: OTA is not supported for BYOD devices. Flash a compatible version directly from trmnl.com/flash
       maximum_compatibility: Enable Maximum Compatibility
-      maximum_compatibility_hint: Resolves display issues caused by certain e-ink driver chips. Disables fast refresh. Firmware 1.6.0+ required.
+      maximum_compatibility_hint: Resolves display issues caused by certain ePaper driver chips. Disables fast refresh. Firmware 1.6.0+ required.
       color_and_rotation: Warna dan Rotasi Layar
       screen_rotation: Rotasi Layar
       screen_rotation_not_supported: Rotasi layar saat ini tidak didukung pada perangkat Anda.
       palette: Color Palette
-      palette_hint: Select the set of colors to use when generating screens for this device. A larger palette looks nicer, but a smaller palette draws faster on e-ink. Individual playlist items can override this setting.
+      palette_hint: Select the set of colors to use when generating screens for this device. A larger palette looks nicer, but a smaller palette draws faster on ePaper. Individual playlist items can override this setting.
       presentation: Presentation
       sleep_mode: Mode Tidur
       sleep_mode_hint: Sesuaikan tingkat penyegaran untuk fokus dan hemat baterai.

--- a/lib/trmnl/i18n/locales/web_ui/is.yml
+++ b/lib/trmnl/i18n/locales/web_ui/is.yml
@@ -249,7 +249,7 @@ is:
       firmware_updates_enabled: Updates enabled
       firmware_updates_disabled: Updates disabled
       font_family: Font Family
-      font_family_hint: The TRMNL font family was designed for optimal performance on e-ink screens. Supported on plugins with UI Framework v%{min_version}+.
+      font_family_hint: The TRMNL font family was designed for optimal performance on ePaper screens. Supported on plugins with UI Framework v%{min_version}+.
       guest_mode: Gestahamur
       guest_mode_hint: Veldu hvað á að birta (og hversu lengi) þegar gestahamur er virkjaður.
       guest_mode_item_placeholder: Veldu atriði
@@ -272,12 +272,12 @@ is:
       ota_enabled_hint: Setur sjálfkrafa inn nýjan vélbúnað. Slökktu til að nota þinn eigin.
       ota_byod_not_supported: OTA er ekki stutt fyrir BYOD-tæki. "Flassaðu" samhæfða útgáfu beint frá trmnl.com/flash
       maximum_compatibility: Hámarkssamhæfni
-      maximum_compatibility_hint: Leysir skjávandamál af völdum sumra e-ink rekla. Slekkur á hraðri uppfærslu. Krefst fastbúnaðar 1.6.0+.
+      maximum_compatibility_hint: Leysir skjávandamál af völdum sumra ePaper rekla. Slekkur á hraðri uppfærslu. Krefst fastbúnaðar 1.6.0+.
       color_and_rotation: Litur og Snúningur
       screen_rotation: Skjásnúningur
       screen_rotation_not_supported: Skjásnúningur er ekki í boði fyrir þetta tæki.
       palette: Color Palette
-      palette_hint: Select the set of colors to use when generating screens for this device. A larger palette looks nicer, but a smaller palette draws faster on e-ink. Individual playlist items can override this setting.
+      palette_hint: Select the set of colors to use when generating screens for this device. A larger palette looks nicer, but a smaller palette draws faster on ePaper. Individual playlist items can override this setting.
       presentation: Presentation
       sleep_mode: Svefnhamur
       sleep_mode_hint: Stilltu uppfærslutíðni til að bæta einbeitingu og lengja rafhlöðuendingu.

--- a/lib/trmnl/i18n/locales/web_ui/it.yml
+++ b/lib/trmnl/i18n/locales/web_ui/it.yml
@@ -249,7 +249,7 @@ it:
       firmware_updates_enabled: Aggiornamenti attivi
       firmware_updates_disabled: Aggiornamenti disattivati
       font_family: Font Family
-      font_family_hint: The TRMNL font family was designed for optimal performance on e-ink screens. Supported on plugins with UI Framework v%{min_version}+.
+      font_family_hint: The TRMNL font family was designed for optimal performance on ePaper screens. Supported on plugins with UI Framework v%{min_version}+.
       guest_mode: Modalità Ospite
       guest_mode_hint: Scegli cosa mostrare (e per quanto tempo) quando la modalità ospite è attiva.
       guest_mode_item_placeholder: Scegli un elemento
@@ -272,7 +272,7 @@ it:
       ota_enabled_hint: Installa automaticamente i nuovi firmware. Disabilita per utilizzare il tuo firmware
       ota_byod_not_supported: OTA is not supported for BYOD devices. Flash a compatible version directly from trmnl.com/flash
       maximum_compatibility: Abilita compatibilità massima
-      maximum_compatibility_hint: Risolve problemi dello schermo causati da alcuni chip driver per e-ink. Disattiva il fast refresh. Richiede Firmware 1.6.0 o successivo.
+      maximum_compatibility_hint: Risolve problemi dello schermo causati da alcuni chip driver per ePaper. Disattiva il fast refresh. Richiede Firmware 1.6.0 o successivo.
       color_and_rotation: Colore e Rotazione
       screen_rotation: Rotazione Schermo
       screen_rotation_not_supported: La rotazione dello schermo non è attualmente supportata sul tuo dispositivo.

--- a/lib/trmnl/i18n/locales/web_ui/ja.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ja.yml
@@ -249,7 +249,7 @@ ja:
       firmware_updates_enabled: Updates enabled
       firmware_updates_disabled: Updates disabled
       font_family: Font Family
-      font_family_hint: The TRMNL font family was designed for optimal performance on e-ink screens. Supported on plugins with UI Framework v%{min_version}+.
+      font_family_hint: The TRMNL font family was designed for optimal performance on ePaper screens. Supported on plugins with UI Framework v%{min_version}+.
       guest_mode: Guest Mode
       guest_mode_hint: Choose what to display (and for how long) whenever guest mode is enabled.
       guest_mode_item_placeholder: Choose an item
@@ -272,12 +272,12 @@ ja:
       ota_enabled_hint: 新しいファームウェアを自動的にインストールします。独自のファームウェアを使用するには無効にしてください。
       ota_byod_not_supported: OTA is not supported for BYOD devices. Flash a compatible version directly from trmnl.com/flash
       maximum_compatibility: Enable Maximum Compatibility
-      maximum_compatibility_hint: Resolves display issues caused by certain e-ink driver chips. Disables fast refresh. Firmware 1.6.0+ required.
+      maximum_compatibility_hint: Resolves display issues caused by certain ePaper driver chips. Disables fast refresh. Firmware 1.6.0+ required.
       color_and_rotation: 色と回転
       screen_rotation: 画面回転
       screen_rotation_not_supported: 画面回転は現在、あなたのデバイスではサポートされていません。
       palette: Color Palette
-      palette_hint: Select the set of colors to use when generating screens for this device. A larger palette looks nicer, but a smaller palette draws faster on e-ink. Individual playlist items can override this setting.
+      palette_hint: Select the set of colors to use when generating screens for this device. A larger palette looks nicer, but a smaller palette draws faster on ePaper. Individual playlist items can override this setting.
       presentation: Presentation
       sleep_mode: スリープモード
       sleep_mode_hint: 集中力とバッテリー寿命を最適化するために、更新頻度を調整します。

--- a/lib/trmnl/i18n/locales/web_ui/ko.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ko.yml
@@ -249,7 +249,7 @@ ko:
       firmware_updates_enabled: 업데이트 활성화됨
       firmware_updates_disabled: 업데이트 비활성화됨
       font_family: Font Family
-      font_family_hint: The TRMNL font family was designed for optimal performance on e-ink screens. Supported on plugins with UI Framework v%{min_version}+.
+      font_family_hint: The TRMNL font family was designed for optimal performance on ePaper screens. Supported on plugins with UI Framework v%{min_version}+.
       guest_mode: 게스트 모드
       guest_mode_hint: 게스트 모드로 전환될 때 무엇을 화면에 띄우고 얼마나 오래 띄울지 고르세요.
       guest_mode_item_placeholder: 아이템을 고르세요
@@ -272,12 +272,12 @@ ko:
       ota_enabled_hint: 새 펌웨어를 자동으로 설치해요. 직접 만든 펌웨어를 쓰려면 비활성화하세요.
       ota_byod_not_supported: BYOD 기기는 OTA를 지원하지 않아요. trmnl.com/flash에서 직접 플래시하세요.
       maximum_compatibility: 최대 호환성 활성화
-      maximum_compatibility_hint: 특정 e-ink 드라이버 칩의 디스플레이 문제를 해결해요. 빠른 새로고침이 비활성화돼요. 펌웨어 1.6.0 이상 필요.
+      maximum_compatibility_hint: 특정 ePaper 드라이버 칩의 디스플레이 문제를 해결해요. 빠른 새로고침이 비활성화돼요. 펌웨어 1.6.0 이상 필요.
       color_and_rotation: 색상과 회전
       screen_rotation: 화면 회전
       screen_rotation_not_supported: 화면 회전은 현재 지원되지 않아요.
       palette: 색상 팔레트
-      palette_hint: 화면 생성에 사용할 색상을 선택하세요. 팔레트가 클수록 보기 좋지만, 작을수록 e-ink에서 빠르게 그려져요. 개별 플레이리스트 항목에서 재설정할 수 있어요.
+      palette_hint: 화면 생성에 사용할 색상을 선택하세요. 팔레트가 클수록 보기 좋지만, 작을수록 ePaper에서 빠르게 그려져요. 개별 플레이리스트 항목에서 재설정할 수 있어요.
       presentation: Presentation
       sleep_mode: 절전 모드
       sleep_mode_hint: 새로고침 주기를 조정해서 집중력과 배터리를 아끼세요.

--- a/lib/trmnl/i18n/locales/web_ui/lt.yml
+++ b/lib/trmnl/i18n/locales/web_ui/lt.yml
@@ -249,7 +249,7 @@ lt:
       firmware_updates_enabled: Atnaujinimai įjungti
       firmware_updates_disabled: Atnaujinimai išjungti
       font_family: Font Family
-      font_family_hint: The TRMNL font family was designed for optimal performance on e-ink screens. Supported on plugins with UI Framework v%{min_version}+.
+      font_family_hint: The TRMNL font family was designed for optimal performance on ePaper screens. Supported on plugins with UI Framework v%{min_version}+.
       guest_mode: Svečio režimas
       guest_mode_hint: Pasirinkite, ką rodyti (ir kiek laiko), kai įjungtas svečio režimas.
       guest_mode_item_placeholder: Pasirinkite elementą
@@ -272,12 +272,12 @@ lt:
       ota_enabled_hint: Automatiškai įdiegti naują programinę įrangą. Išjunkite, kad naudotumėte savo programinę įrangą.
       ota_byod_not_supported: OTA nepalaikoma BYOD įrenginiuose. Įrašykite suderinamą versiją tiesiogiai iš trmnl.com/flash
       maximum_compatibility: Įjungti maksimalų suderinamumą
-      maximum_compatibility_hint: Išsprendžia ekrano problemas, kurias sukelia tam tikros e-ink tvarkyklės. Išjungia greitąjį atnaujinimą. Reikalinga programinė įranga 1.6.0+.
+      maximum_compatibility_hint: Išsprendžia ekrano problemas, kurias sukelia tam tikros ePaper tvarkyklės. Išjungia greitąjį atnaujinimą. Reikalinga programinė įranga 1.6.0+.
       color_and_rotation: Spalvų ir ratavimas
       screen_rotation: Ekranų ratavimas
       screen_rotation_not_supported: Ekranų ratavimas šiuo metu nepalaikomas jūsų įrenginyje.
       palette: Spalvų paletė
-      palette_hint: Pasirinkite spalvų rinkinį, kuris bus naudojamas generuojant šio įrenginio ekranus. Didesnė paletė atrodo gražiau, tačiau mažesnė paletė e-ink ekrane piešiama greičiau. Atskiri grojaraščio elementai gali perrašyti šį nustatymą.
+      palette_hint: Pasirinkite spalvų rinkinį, kuris bus naudojamas generuojant šio įrenginio ekranus. Didesnė paletė atrodo gražiau, tačiau mažesnė paletė ePaper ekrane piešiama greičiau. Atskiri grojaraščio elementai gali perrašyti šį nustatymą.
       presentation: Presentation
       sleep_mode: Miego režimas
       sleep_mode_hint: Sureguliuokite atnaujinimo dažnį, kad optimizuotumėte dėmesio sutelkimą ir baterijos veikimo laiką.

--- a/lib/trmnl/i18n/locales/web_ui/nl.yml
+++ b/lib/trmnl/i18n/locales/web_ui/nl.yml
@@ -249,7 +249,7 @@ nl:
       firmware_updates_enabled: Updates enabled
       firmware_updates_disabled: Updates disabled
       font_family: Font Family
-      font_family_hint: The TRMNL font family was designed for optimal performance on e-ink screens. Supported on plugins with UI Framework v%{min_version}+.
+      font_family_hint: The TRMNL font family was designed for optimal performance on ePaper screens. Supported on plugins with UI Framework v%{min_version}+.
       guest_mode: Gast Modus
       guest_mode_hint: Kies wat je wil tonen (en voor hoe lang) in gast modus.
       guest_mode_item_placeholder: Kies een item
@@ -272,12 +272,12 @@ nl:
       ota_enabled_hint: Installeer automatisch nieuwe firmware. Deactiveer als je je je eigen firmware wil gebruiken.
       ota_byod_not_supported: OTA is not supported for BYOD devices. Flash a compatible version directly from trmnl.com/flash
       maximum_compatibility: Activeer Maximale Compatibiliteit
-      maximum_compatibility_hint: Los scherm issues op met bepaalde e-ink driver chips. Zet snelle verversing uit. Firmware 1.6.0+ benodigd.
+      maximum_compatibility_hint: Los scherm issues op met bepaalde ePaper driver chips. Zet snelle verversing uit. Firmware 1.6.0+ benodigd.
       color_and_rotation: Kleur en rotatie
       screen_rotation: Schermrotatie
       screen_rotation_not_supported: Schermrotatie is momenteel niet ondersteund op je apparaat.
       palette: Color Palette
-      palette_hint: Select the set of colors to use when generating screens for this device. A larger palette looks nicer, but a smaller palette draws faster on e-ink. Individual playlist items can override this setting.
+      palette_hint: Select the set of colors to use when generating screens for this device. A larger palette looks nicer, but a smaller palette draws faster on ePaper. Individual playlist items can override this setting.
       presentation: Presentation
       sleep_mode: Slaapmodus
       sleep_mode_hint: Pas de refresh rate aan om focus en batterijduur te optimaliseren.

--- a/lib/trmnl/i18n/locales/web_ui/no.yml
+++ b/lib/trmnl/i18n/locales/web_ui/no.yml
@@ -249,7 +249,7 @@
       firmware_updates_enabled: Updates enabled
       firmware_updates_disabled: Updates disabled
       font_family: Font Family
-      font_family_hint: The TRMNL font family was designed for optimal performance on e-ink screens. Supported on plugins with UI Framework v%{min_version}+.
+      font_family_hint: The TRMNL font family was designed for optimal performance on ePaper screens. Supported on plugins with UI Framework v%{min_version}+.
       guest_mode: Guest Mode
       guest_mode_hint: Choose what to display (and for how long) whenever guest mode is enabled.
       guest_mode_item_placeholder: Choose an item
@@ -272,12 +272,12 @@
       ota_enabled_hint: Installerer automatisk ny fastvare. Deaktiver for å bruke din egen fastvare.
       ota_byod_not_supported: OTA is not supported for BYOD devices. Flash a compatible version directly from trmnl.com/flash
       maximum_compatibility: Enable Maximum Compatibility
-      maximum_compatibility_hint: Resolves display issues caused by certain e-ink driver chips. Disables fast refresh. Firmware 1.6.0+ required.
+      maximum_compatibility_hint: Resolves display issues caused by certain ePaper driver chips. Disables fast refresh. Firmware 1.6.0+ required.
       color_and_rotation: Farge og rotasjon
       screen_rotation: Skjermrotasjon
       screen_rotation_not_supported: Skjermrotasjon er ikke understøttet på din enhet.
       palette: Color Palette
-      palette_hint: Select the set of colors to use when generating screens for this device. A larger palette looks nicer, but a smaller palette draws faster on e-ink. Individual playlist items can override this setting.
+      palette_hint: Select the set of colors to use when generating screens for this device. A larger palette looks nicer, but a smaller palette draws faster on ePaper. Individual playlist items can override this setting.
       presentation: Presentation
       sleep_mode: Dvalemodus
       sleep_mode_hint: Juster oppdateringsfrekvensen for å optimalisere fokus og batterilevetid.

--- a/lib/trmnl/i18n/locales/web_ui/pl.yml
+++ b/lib/trmnl/i18n/locales/web_ui/pl.yml
@@ -271,7 +271,7 @@ pl:
       firmware_updates_enabled: Aktualizacje włączone
       firmware_updates_disabled: Aktualizacje wyłączone
       font_family: Font Family
-      font_family_hint: The TRMNL font family was designed for optimal performance on e-ink screens. Supported on plugins with UI Framework v%{min_version}+.
+      font_family_hint: The TRMNL font family was designed for optimal performance on ePaper screens. Supported on plugins with UI Framework v%{min_version}+.
       guest_mode: Tryb gościa
       guest_mode_hint: Wybierz co ma być wyświetlane (i przez jaki czas), kiedy tryb gościa jest włączony.
       guest_mode_item_placeholder: Wybierz element
@@ -294,12 +294,12 @@ pl:
       ota_enabled_hint: Automatycznie instaluj nowy firmware. Wyłącz, jeśli chcesz instalować własny firmware.
       ota_byod_not_supported: Aktualizacje OTA nie są wspierane na urządzeniach firm trzecich (BYOD). Wgraj kompatybilne oprogramowanie ze strony trmnl.com/flash
       maximum_compatibility: Włącz maksymalną kompatybilność
-      maximum_compatibility_hint: Rozwiązuje problemy z wyświetlaniem na niektórych wyświetlaczach e-ink. Wyłącza szybkie odświeżanie. Wymaga oprogramowania 1.6.0 lub nowszego.
+      maximum_compatibility_hint: Rozwiązuje problemy z wyświetlaniem na niektórych wyświetlaczach ePaper. Wyłącza szybkie odświeżanie. Wymaga oprogramowania 1.6.0 lub nowszego.
       color_and_rotation: Kolor i obrót
       screen_rotation: Obrót ekranu
       screen_rotation_not_supported: Obrót ekranu nie jest obecnie obsługiwany na Twoim urządzeniu.
       palette: Paleta kolorów
-      palette_hint: Wybierz zestaw kolorów, który ma być wyświetlany na tym urządzeniu. Większa paleta wygląda lepiej, ale mniejsza jest szybciej rysowana na wyświetlaczach e-ink. Ustawienie to da się zmienić indywidualnie dla każdego elementu playlisty.
+      palette_hint: Wybierz zestaw kolorów, który ma być wyświetlany na tym urządzeniu. Większa paleta wygląda lepiej, ale mniejsza jest szybciej rysowana na wyświetlaczach ePaper. Ustawienie to da się zmienić indywidualnie dla każdego elementu playlisty.
       presentation: Presentation
       sleep_mode: Tryb uśpienia
       sleep_mode_hint: Dostosuj częstotliwość odświeżania, aby zoptymalizować skupienie i wydłużyć czas pracy na baterii.

--- a/lib/trmnl/i18n/locales/web_ui/pt-BR.yml
+++ b/lib/trmnl/i18n/locales/web_ui/pt-BR.yml
@@ -249,7 +249,7 @@ pt-BR:
       firmware_updates_enabled: Updates enabled
       firmware_updates_disabled: Updates disabled
       font_family: Font Family
-      font_family_hint: The TRMNL font family was designed for optimal performance on e-ink screens. Supported on plugins with UI Framework v%{min_version}+.
+      font_family_hint: The TRMNL font family was designed for optimal performance on ePaper screens. Supported on plugins with UI Framework v%{min_version}+.
       guest_mode: Modo Convidado
       guest_mode_hint: Escolha o que exibir (e por quanto tempo) quando o modo convidado está ativado.
       guest_mode_item_placeholder: Escolha um item
@@ -272,12 +272,12 @@ pt-BR:
       ota_enabled_hint: Instalar novos firmwares automaticamente. Desative para usar seu próprio firmware.
       ota_byod_not_supported: OTA não é suportado em dispositivos BYOD. Instale uma versão compatível diretamente de trmnl.com/flash
       maximum_compatibility: Habilitar Compatibilidade Máxima
-      maximum_compatibility_hint: Resolve problemas de exibição causados por determinados chips e-ink. Desabilida a atualização rápida. Requer o firmware 1.6.0+.
+      maximum_compatibility_hint: Resolve problemas de exibição causados por determinados chips ePaper. Desabilida a atualização rápida. Requer o firmware 1.6.0+.
       color_and_rotation: Color & Rotation
       screen_rotation: Screen Rotation
       screen_rotation_not_supported: A rotação da tela não é suportada no seu dispositivo.
       palette: Color Palette
-      palette_hint: Select the set of colors to use when generating screens for this device. A larger palette looks nicer, but a smaller palette draws faster on e-ink. Individual playlist items can override this setting.
+      palette_hint: Select the set of colors to use when generating screens for this device. A larger palette looks nicer, but a smaller palette draws faster on ePaper. Individual playlist items can override this setting.
       presentation: Presentation
       sleep_mode: Modo de Descanso
       sleep_mode_hint: Ajuste sua taxa de atualização para otimizar foco e duração da bateria.

--- a/lib/trmnl/i18n/locales/web_ui/ro.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ro.yml
@@ -249,7 +249,7 @@ ro:
       firmware_updates_enabled: Actualizări activate
       firmware_updates_disabled: Actualizări dezactivate
       font_family: Font Family
-      font_family_hint: The TRMNL font family was designed for optimal performance on e-ink screens. Supported on plugins with UI Framework v%{min_version}+.
+      font_family_hint: The TRMNL font family was designed for optimal performance on ePaper screens. Supported on plugins with UI Framework v%{min_version}+.
       guest_mode: Mod oaspete
       guest_mode_hint: Alege ce să afișezi (și pentru cât timp) ori de câte ori modul oaspete este activat.
       guest_mode_item_placeholder: Alege un element
@@ -272,12 +272,12 @@ ro:
       ota_enabled_hint: Instalează automat firmware nou. Dezactivează pentru a folosi propriul firmware.
       ota_byod_not_supported: OTA nu este suportat pentru dispozitivele BYOD. Instalează o versiune compatibilă direct de pe trmnl.com/flash
       maximum_compatibility: Activează compatibilitate maximă
-      maximum_compatibility_hint: Rezolvă problemele de afișare cauzate de anumite chipuri de driver e-ink. Dezactivează reîmprospătarea rapidă. Necesită firmware 1.6.0+.
+      maximum_compatibility_hint: Rezolvă problemele de afișare cauzate de anumite chipuri de driver ePaper. Dezactivează reîmprospătarea rapidă. Necesită firmware 1.6.0+.
       color_and_rotation: Culoare și rotație
       screen_rotation: Rotație ecran
       screen_rotation_not_supported: Rotația ecranului nu este în prezent suportată pe dispozitivul tău.
       palette: Paletă de culori
-      palette_hint: Selectează setul de culori de folosit la generarea ecranelor pentru acest dispozitiv. O paletă mai mare arată mai bine, dar una mai mică se desenează mai rapid pe e-ink. Elementele individuale din listă pot suprascrie această setare.
+      palette_hint: Selectează setul de culori de folosit la generarea ecranelor pentru acest dispozitiv. O paletă mai mare arată mai bine, dar una mai mică se desenează mai rapid pe ePaper. Elementele individuale din listă pot suprascrie această setare.
       presentation: Presentation
       sleep_mode: Mod repaus
       sleep_mode_hint: Ajustează rata de reîmprospătare pentru a optimiza concentrarea și durata bateriei.

--- a/lib/trmnl/i18n/locales/web_ui/ru.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ru.yml
@@ -271,7 +271,7 @@ ru:
       firmware_updates_enabled: Updates enabled
       firmware_updates_disabled: Updates disabled
       font_family: Font Family
-      font_family_hint: The TRMNL font family was designed for optimal performance on e-ink screens. Supported on plugins with UI Framework v%{min_version}+.
+      font_family_hint: The TRMNL font family was designed for optimal performance on ePaper screens. Supported on plugins with UI Framework v%{min_version}+.
       guest_mode: Гостевой режим
       guest_mode_hint: Выберите, что отображать (и на какой срок) при включении гостевого режима.
       guest_mode_item_placeholder: Выберите элемент
@@ -294,12 +294,12 @@ ru:
       ota_enabled_hint: Автоматически устанавливать новую прошивку. Отключите, чтобы использовать собственную прошивку.
       ota_byod_not_supported: OTA не поддерживается для устройств BYOD. Прошейте совместимую версию прямо с trmnl.com/flash
       maximum_compatibility: Включить максимальную совместимость
-      maximum_compatibility_hint: Устраняет проблемы с отображением, вызванные некоторыми чипами драйверов e-ink. Отключает быстрое обновление. Требуется прошивка 1.6.0+.
+      maximum_compatibility_hint: Устраняет проблемы с отображением, вызванные некоторыми чипами драйверов ePaper. Отключает быстрое обновление. Требуется прошивка 1.6.0+.
       color_and_rotation: Color & Rotation
       screen_rotation: Screen Rotation
       screen_rotation_not_supported: Вращение экрана в настоящее время не поддерживается на вашем устройстве.
       palette: Color Palette
-      palette_hint: Select the set of colors to use when generating screens for this device. A larger palette looks nicer, but a smaller palette draws faster on e-ink. Individual playlist items can override this setting.
+      palette_hint: Select the set of colors to use when generating screens for this device. A larger palette looks nicer, but a smaller palette draws faster on ePaper. Individual playlist items can override this setting.
       presentation: Presentation
       sleep_mode: Спящий режим
       sleep_mode_hint: Настройте частоту обновления для оптимизации фокусировки и времени автономной работы.

--- a/lib/trmnl/i18n/locales/web_ui/sk.yml
+++ b/lib/trmnl/i18n/locales/web_ui/sk.yml
@@ -260,7 +260,7 @@ sk:
       firmware_updates_enabled: Updates enabled
       firmware_updates_disabled: Updates disabled
       font_family: Font Family
-      font_family_hint: The TRMNL font family was designed for optimal performance on e-ink screens. Supported on plugins with UI Framework v%{min_version}+.
+      font_family_hint: The TRMNL font family was designed for optimal performance on ePaper screens. Supported on plugins with UI Framework v%{min_version}+.
       guest_mode: Guest Mode
       guest_mode_hint: Choose what to display (and for how long) whenever guest mode is enabled.
       guest_mode_item_placeholder: Choose an item
@@ -283,12 +283,12 @@ sk:
       ota_enabled_hint: Automatically install new firmware. Disable to use your own firmware.
       ota_byod_not_supported: OTA is not supported for BYOD devices. Flash a compatible version directly from trmnl.com/flash
       maximum_compatibility: Enable Maximum Compatibility
-      maximum_compatibility_hint: Resolves display issues caused by certain e-ink driver chips. Disables fast refresh. Firmware 1.6.0+ required.
+      maximum_compatibility_hint: Resolves display issues caused by certain ePaper driver chips. Disables fast refresh. Firmware 1.6.0+ required.
       color_and_rotation: Farba a otáčanie
       screen_rotation: Otáčanie obrazovky
       screen_rotation_not_supported: Otáčanie obrazovky nie je momentálne podporované na vašom zariadení.
       palette: Color Palette
-      palette_hint: Select the set of colors to use when generating screens for this device. A larger palette looks nicer, but a smaller palette draws faster on e-ink. Individual playlist items can override this setting.
+      palette_hint: Select the set of colors to use when generating screens for this device. A larger palette looks nicer, but a smaller palette draws faster on ePaper. Individual playlist items can override this setting.
       presentation: Presentation
       sleep_mode: Sleep Mode
       sleep_mode_hint: Adjust your refresh rate to optimize focus and battery life.

--- a/lib/trmnl/i18n/locales/web_ui/sv.yml
+++ b/lib/trmnl/i18n/locales/web_ui/sv.yml
@@ -249,7 +249,7 @@ sv:
       firmware_updates_enabled: Updates enabled
       firmware_updates_disabled: Updates disabled
       font_family: Font Family
-      font_family_hint: The TRMNL font family was designed for optimal performance on e-ink screens. Supported on plugins with UI Framework v%{min_version}+.
+      font_family_hint: The TRMNL font family was designed for optimal performance on ePaper screens. Supported on plugins with UI Framework v%{min_version}+.
       guest_mode: Guest Mode
       guest_mode_hint: Choose what to display (and for how long) whenever guest mode is enabled.
       guest_mode_item_placeholder: Choose an item
@@ -272,12 +272,12 @@ sv:
       ota_enabled_hint: Automatically install new firmware. Disable to use your own firmware.
       ota_byod_not_supported: OTA is not supported for BYOD devices. Flash a compatible version directly from trmnl.com/flash
       maximum_compatibility: Enable Maximum Compatibility
-      maximum_compatibility_hint: Resolves display issues caused by certain e-ink driver chips. Disables fast refresh. Firmware 1.6.0+ required.
+      maximum_compatibility_hint: Resolves display issues caused by certain ePaper driver chips. Disables fast refresh. Firmware 1.6.0+ required.
       color_and_rotation: Färg och rotation
       screen_rotation: Skärmrotation
       screen_rotation_not_supported: Skärmrotation stöds för närvarande inte på din enhet.
       palette: Color Palette
-      palette_hint: Select the set of colors to use when generating screens for this device. A larger palette looks nicer, but a smaller palette draws faster on e-ink. Individual playlist items can override this setting.
+      palette_hint: Select the set of colors to use when generating screens for this device. A larger palette looks nicer, but a smaller palette draws faster on ePaper. Individual playlist items can override this setting.
       presentation: Presentation
       sleep_mode: Sleep Mode
       sleep_mode_hint: Adjust your refresh rate to optimize focus and battery life.

--- a/lib/trmnl/i18n/locales/web_ui/uk.yml
+++ b/lib/trmnl/i18n/locales/web_ui/uk.yml
@@ -271,7 +271,7 @@ uk:
       firmware_updates_enabled: Updates enabled
       firmware_updates_disabled: Updates disabled
       font_family: Font Family
-      font_family_hint: The TRMNL font family was designed for optimal performance on e-ink screens. Supported on plugins with UI Framework v%{min_version}+.
+      font_family_hint: The TRMNL font family was designed for optimal performance on ePaper screens. Supported on plugins with UI Framework v%{min_version}+.
       guest_mode: Guest Mode
       guest_mode_hint: Choose what to display (and for how long) whenever guest mode is enabled.
       guest_mode_item_placeholder: Choose an item
@@ -294,12 +294,12 @@ uk:
       ota_enabled_hint: Automatically install new firmware. Disable to use your own firmware.
       ota_byod_not_supported: OTA is not supported for BYOD devices. Flash a compatible version directly from trmnl.com/flash
       maximum_compatibility: Enable Maximum Compatibility
-      maximum_compatibility_hint: Resolves display issues caused by certain e-ink driver chips. Disables fast refresh. Firmware 1.6.0+ required.
+      maximum_compatibility_hint: Resolves display issues caused by certain ePaper driver chips. Disables fast refresh. Firmware 1.6.0+ required.
       color_and_rotation: Колір і обертання
       screen_rotation: Обертання екрану
       screen_rotation_not_supported: Обертання екрану в даний час не підтримується на вашому пристрої.
       palette: Color Palette
-      palette_hint: Select the set of colors to use when generating screens for this device. A larger palette looks nicer, but a smaller palette draws faster on e-ink. Individual playlist items can override this setting.
+      palette_hint: Select the set of colors to use when generating screens for this device. A larger palette looks nicer, but a smaller palette draws faster on ePaper. Individual playlist items can override this setting.
       presentation: Presentation
       sleep_mode: Режим сну
       sleep_mode_hint: Налаштуйте частоту оновлення, щоб покращити концентрацію та час роботи батареї.

--- a/lib/trmnl/i18n/locales/web_ui/zh-CN.yml
+++ b/lib/trmnl/i18n/locales/web_ui/zh-CN.yml
@@ -284,7 +284,7 @@ zh-CN:
       firmware_updates_enabled: 更新已启用
       firmware_updates_disabled: 更新已禁用
       font_family: Font Family
-      font_family_hint: The TRMNL font family was designed for optimal performance on e-ink screens. Supported on plugins with UI Framework v%{min_version}+.
+      font_family_hint: The TRMNL font family was designed for optimal performance on ePaper screens. Supported on plugins with UI Framework v%{min_version}+.
       guest_mode: 访客模式
       guest_mode_hint: 设置访客模式下显示的内容与时长。
       guest_mode_item_placeholder: 选择项目

--- a/lib/trmnl/i18n/locales/web_ui/zh-HK.yml
+++ b/lib/trmnl/i18n/locales/web_ui/zh-HK.yml
@@ -249,7 +249,7 @@ zh-HK:
       firmware_updates_enabled: 已啟用更新
       firmware_updates_disabled: 已停用更新
       font_family: Font Family
-      font_family_hint: The TRMNL font family was designed for optimal performance on e-ink screens. Supported on plugins with UI Framework v%{min_version}+.
+      font_family_hint: The TRMNL font family was designed for optimal performance on ePaper screens. Supported on plugins with UI Framework v%{min_version}+.
       guest_mode: 訪客模式
       guest_mode_hint: 選擇啟用訪客模式時顯示的內容（以及顯示多久）。
       guest_mode_item_placeholder: 選擇項目


### PR DESCRIPTION
- Translate 31 missing German strings in web_ui/de.yml and plugin_renders/de.yml (plus Austrian variant)
- Replace "e-ink" / "E-Ink" with "ePaper" in all locale files
