### PR TITLE
Add actions key; translate actions, switch.title, go_to_settings in de/de-AT

### DIFF
--- a/lib/trmnl/i18n/locales/web_ui/da.yml
+++ b/lib/trmnl/i18n/locales/web_ui/da.yml
@@ -2,6 +2,7 @@
 da:
   locale_name: Dansk
   about: About
+  actions: Actions
   add: Tilføj
   add_new: Tilføj ny
   ai_assistant: Agent

--- a/lib/trmnl/i18n/locales/web_ui/de-AT.yml
+++ b/lib/trmnl/i18n/locales/web_ui/de-AT.yml
@@ -2,6 +2,7 @@
 de-AT:
   locale_name: Deutsch (Österreich)
   about: Über
+  actions: Aktionen
   add: Hinzufügen
   add_new: Neu hinzufügen
   ai_assistant: Agent
@@ -315,7 +316,7 @@ de-AT:
       tagline: Deine TRMNL-Geräte
       add_device_modal_title: Neues Gerät hinzufügen
       add_first_device: Beginne mit dem Hinzufügen deines ersten Gerätes!
-      go_to_settings: Go to settings
+      go_to_settings: Zu den Einstellungen
     new:
       title: Neues Gerät hinzufügen
       description: Gib deine Gerätekennung ein, um ein neues Gerät zu deinem Konto hinzuzufügen.
@@ -341,7 +342,7 @@ de-AT:
     switch:
       error: Fehler beim Wechseln des Gerätes
       success: Gerät erfolgreich gewechselt
-      title: Switch to device
+      title: Zu Gerät wechseln
     update:
       error: Fehler beim Aktualisieren des Gerätes
       success: Einstellungen von %{device} erfolgreich aktualisiert

--- a/lib/trmnl/i18n/locales/web_ui/de.yml
+++ b/lib/trmnl/i18n/locales/web_ui/de.yml
@@ -2,6 +2,7 @@
 de:
   locale_name: Deutsch
   about: Über
+  actions: Aktionen
   add: Hinzufügen
   add_new: Neu hinzufügen
   ai_assistant: Agent
@@ -315,7 +316,7 @@ de:
       tagline: Deine TRMNL-Geräte
       add_device_modal_title: Neues Gerät hinzufügen
       add_first_device: Beginne mit dem Hinzufügen deines ersten Gerätes!
-      go_to_settings: Go to settings
+      go_to_settings: Zu den Einstellungen
     new:
       title: Neues Gerät hinzufügen
       description: Gib deine Gerätekennung ein, um ein neues Gerät zu deinem Konto hinzuzufügen.
@@ -341,7 +342,7 @@ de:
     switch:
       error: Fehler beim Wechseln des Gerätes
       success: Gerät erfolgreich gewechselt
-      title: Switch to device
+      title: Zu Gerät wechseln
     update:
       error: Fehler beim Aktualisieren des Gerätes
       success: Einstellungen von %{device} erfolgreich aktualisiert

--- a/lib/trmnl/i18n/locales/web_ui/en-GB.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en-GB.yml
@@ -2,6 +2,7 @@
 en-GB:
   locale_name: English (United Kingdom)
   about: About
+  actions: Actions
   add: Add
   add_new: Add new
   ai_assistant: Agent

--- a/lib/trmnl/i18n/locales/web_ui/en.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en.yml
@@ -2,6 +2,7 @@
 en:
   locale_name: English
   about: About
+  actions: Actions
   add: Add
   add_new: Add new
   ai_assistant: Agent

--- a/lib/trmnl/i18n/locales/web_ui/es-ES.yml
+++ b/lib/trmnl/i18n/locales/web_ui/es-ES.yml
@@ -2,6 +2,7 @@
 es-ES:
   locale_name: Español (España)
   about: Acerca de
+  actions: Actions
   add: Crear
   add_new: Crear nueva
   ai_assistant: Agent

--- a/lib/trmnl/i18n/locales/web_ui/fr.yml
+++ b/lib/trmnl/i18n/locales/web_ui/fr.yml
@@ -2,6 +2,7 @@
 fr:
   locale_name: Français
   about: À propos
+  actions: Actions
   add: Ajouter
   add_new: Ajouter
   ai_assistant: Agent

--- a/lib/trmnl/i18n/locales/web_ui/he.yml
+++ b/lib/trmnl/i18n/locales/web_ui/he.yml
@@ -2,6 +2,7 @@
 he:
   locale_name: Hebrew
   about: About
+  actions: Actions
   add: Add
   add_new: Add new
   ai_assistant: Agent

--- a/lib/trmnl/i18n/locales/web_ui/hu.yml
+++ b/lib/trmnl/i18n/locales/web_ui/hu.yml
@@ -2,6 +2,7 @@
 hu:
   locale_name: Magyar
   about: About
+  actions: Actions
   add: Hozzáadás
   add_new: Új hozzáadása
   ai_assistant: Agent

--- a/lib/trmnl/i18n/locales/web_ui/id.yml
+++ b/lib/trmnl/i18n/locales/web_ui/id.yml
@@ -2,6 +2,7 @@
 id:
   locale_name: Indonesian
   about: About
+  actions: Actions
   add: Tambah
   add_new: Tambah baru
   ai_assistant: Agent

--- a/lib/trmnl/i18n/locales/web_ui/is.yml
+++ b/lib/trmnl/i18n/locales/web_ui/is.yml
@@ -2,6 +2,7 @@
 is:
   locale_name: Íslenska
   about: About
+  actions: Actions
   add: Bæta við
   add_new: Bæta nýju við
   ai_assistant: Agent

--- a/lib/trmnl/i18n/locales/web_ui/it.yml
+++ b/lib/trmnl/i18n/locales/web_ui/it.yml
@@ -2,6 +2,7 @@
 it:
   locale_name: Italiano
   about: Informazioni
+  actions: Actions
   add: Aggiungi
   add_new: Aggiungi nuovo
   ai_assistant: Agent

--- a/lib/trmnl/i18n/locales/web_ui/ja.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ja.yml
@@ -2,6 +2,7 @@
 ja:
   locale_name: 日本語
   about: About
+  actions: Actions
   add: 追加
   add_new: 新規追加
   ai_assistant: Agent

--- a/lib/trmnl/i18n/locales/web_ui/ko.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ko.yml
@@ -2,6 +2,7 @@
 ko:
   locale_name: 한국어
   about: 소개
+  actions: Actions
   add: 추가하기
   add_new: 새로 추가하기
   ai_assistant: Agent

--- a/lib/trmnl/i18n/locales/web_ui/lt.yml
+++ b/lib/trmnl/i18n/locales/web_ui/lt.yml
@@ -2,6 +2,7 @@
 lt:
   locale_name: Lietuvių
   about: Apie
+  actions: Actions
   add: Pridėti
   add_new: Pridėti naują
   ai_assistant: Agent

--- a/lib/trmnl/i18n/locales/web_ui/nl.yml
+++ b/lib/trmnl/i18n/locales/web_ui/nl.yml
@@ -2,6 +2,7 @@
 nl:
   locale_name: Dutch
   about: About
+  actions: Actions
   add: Toevoegen
   add_new: Nieuwe toevoegen
   ai_assistant: Agent

--- a/lib/trmnl/i18n/locales/web_ui/no.yml
+++ b/lib/trmnl/i18n/locales/web_ui/no.yml
@@ -2,6 +2,7 @@
 'no':
   locale_name: Norwegian
   about: About
+  actions: Actions
   add: Legg til
   add_new: Legg til ny
   ai_assistant: Agent

--- a/lib/trmnl/i18n/locales/web_ui/pl.yml
+++ b/lib/trmnl/i18n/locales/web_ui/pl.yml
@@ -2,6 +2,7 @@
 pl:
   locale_name: Polski
   about: O nas
+  actions: Actions
   add: Dodaj
   add_new: Dodaj nowy
   ai_assistant: Agent

--- a/lib/trmnl/i18n/locales/web_ui/pt-BR.yml
+++ b/lib/trmnl/i18n/locales/web_ui/pt-BR.yml
@@ -2,6 +2,7 @@
 pt-BR:
   locale_name: Portuguese (Brazil)
   about: Sobre
+  actions: Actions
   add: Adicionar
   add_new: Adicionar novo
   ai_assistant: Agent

--- a/lib/trmnl/i18n/locales/web_ui/raw.yml
+++ b/lib/trmnl/i18n/locales/web_ui/raw.yml
@@ -2,6 +2,7 @@
 raw:
   locale_name: locale_name
   about: about
+  actions: actions
   add: add
   add_new: add_new
   ai_assistant: ai_assistant

--- a/lib/trmnl/i18n/locales/web_ui/ro.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ro.yml
@@ -2,6 +2,7 @@
 ro:
   locale_name: Română
   about: Despre
+  actions: Actions
   add: Adaugă
   add_new: Adaugă nou
   ai_assistant: Agent

--- a/lib/trmnl/i18n/locales/web_ui/ru.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ru.yml
@@ -2,6 +2,7 @@
 ru:
   locale_name: Русский
   about: About
+  actions: Actions
   add: Добавить
   add_new: Добавить новый
   ai_assistant: Agent

--- a/lib/trmnl/i18n/locales/web_ui/sk.yml
+++ b/lib/trmnl/i18n/locales/web_ui/sk.yml
@@ -2,6 +2,7 @@
 sk:
   locale_name: Slovak
   about: About
+  actions: Actions
   add: Add
   add_new: Add new
   ai_assistant: Agent

--- a/lib/trmnl/i18n/locales/web_ui/sv.yml
+++ b/lib/trmnl/i18n/locales/web_ui/sv.yml
@@ -2,6 +2,7 @@
 sv:
   locale_name: Swedish
   about: About
+  actions: Actions
   add: Add
   add_new: Add new
   ai_assistant: Agent

--- a/lib/trmnl/i18n/locales/web_ui/uk.yml
+++ b/lib/trmnl/i18n/locales/web_ui/uk.yml
@@ -2,6 +2,7 @@
 uk:
   locale_name: Ukrainian
   about: About
+  actions: Actions
   add: Додати
   add_new: Додати новий
   ai_assistant: Agent

--- a/lib/trmnl/i18n/locales/web_ui/zh-CN.yml
+++ b/lib/trmnl/i18n/locales/web_ui/zh-CN.yml
@@ -2,6 +2,7 @@
 zh-CN:
   locale_name: 简体中文
   about: 关于
+  actions: Actions
   add: 添加
   add_new: 添加新设备
   ai_assistant: Agent

--- a/lib/trmnl/i18n/locales/web_ui/zh-HK.yml
+++ b/lib/trmnl/i18n/locales/web_ui/zh-HK.yml
@@ -2,6 +2,7 @@
 zh-HK:
   locale_name: 繁體中文（香港）
   about: 簡介
+  actions: Actions
   add: 加入
   add_new: 新增
   ai_assistant: Agent


### PR DESCRIPTION
- Add missing top-level `actions` key to en.yml and sync to all locales
- Translate `actions`, `devices.switch.title`, and `devices.index.go_to_settings` in de.yml and de-AT.yml (previously synced with English fallback in #252/#254)


