### PR TITLE
Update hidden plugin hint to point to plugin merge

### DIFF
--- a/lib/trmnl/i18n/locales/web_ui/da.yml
+++ b/lib/trmnl/i18n/locales/web_ui/da.yml
@@ -623,7 +623,7 @@ da:
       synced: Synkroniseret
       refresh_paused: Opdatering sat på pause
       refresh_paused_hint: Auto-opdatering er sat på pause. Tilføj til en playliste for at starte igen.
-      refresh_paused_hidden_hint: Auto-opdatering er sat på pause, fordi pluginet er skjult i playlisten. Datasynkronisering er aktiv.
+      refresh_paused_hidden_hint: Auto-refresh is paused because this plugin is hidden. To keep its data fresh for other plugins, use the Plugin Merge strategy.
       refresh_paused_mashup: Opdaterer Mashups
       refresh_paused_mashup_hint: Auto-opdatering af fuldskærmsvisning er på pause. Mashups opdaterer.
       refresh_stopped: Auto-opdatering stoppet. Ret pluginfejl for at fortsætte.

--- a/lib/trmnl/i18n/locales/web_ui/de-AT.yml
+++ b/lib/trmnl/i18n/locales/web_ui/de-AT.yml
@@ -623,7 +623,7 @@ de-AT:
       synced: Synchronisiert
       refresh_paused: Aktualisierung pausiert
       refresh_paused_hint: Automatische Aktualisierung wurde angehalten. Zur Wiedergabeliste hinzufügen, um sie wieder aktualisieren zu lassen.
-      refresh_paused_hidden_hint: Automatische Aktualisierung wurde angehalten, weil die Erweiterung in der Wiedergabeliste versteckt wurde. Datensynchronisierung ist aktiv.
+      refresh_paused_hidden_hint: Auto-refresh is paused because this plugin is hidden. To keep its data fresh for other plugins, use the Plugin Merge strategy.
       refresh_paused_mashup: Mashups aktualisieren
       refresh_paused_mashup_hint: Automatische Aktualisierung der Vollbildansicht pausiert. Mashups werden aktualisiert.
       refresh_stopped: Automatische Aktualisierung angehalten. Bitte zuerst den Fehler in der Erweiterung beheben.

--- a/lib/trmnl/i18n/locales/web_ui/de.yml
+++ b/lib/trmnl/i18n/locales/web_ui/de.yml
@@ -623,7 +623,7 @@ de:
       synced: Synchronisiert
       refresh_paused: Aktualisierung pausiert
       refresh_paused_hint: Automatische Aktualisierung wurde angehalten. Zur Wiedergabeliste hinzufügen, um sie wieder aktualisieren zu lassen.
-      refresh_paused_hidden_hint: Automatische Aktualisierung wurde angehalten, weil die Erweiterung in der Wiedergabeliste versteckt wurde. Datensynchronisierung ist aktiv.
+      refresh_paused_hidden_hint: Auto-refresh is paused because this plugin is hidden. To keep its data fresh for other plugins, use the Plugin Merge strategy.
       refresh_paused_mashup: Mashups aktualisieren
       refresh_paused_mashup_hint: Automatische Aktualisierung der Vollbildansicht pausiert. Mashups werden aktualisiert.
       refresh_stopped: Automatische Aktualisierung angehalten. Bitte zuerst den Fehler in der Erweiterung beheben.

--- a/lib/trmnl/i18n/locales/web_ui/en-GB.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en-GB.yml
@@ -623,7 +623,7 @@ en-GB:
       synced: Synced
       refresh_paused: Refresh Paused
       refresh_paused_hint: Auto-refresh is paused. Add to playlist to start again.
-      refresh_paused_hidden_hint: Auto-refresh is paused because the plugin is hidden in the playlist. Data sync is active.
+      refresh_paused_hidden_hint: Auto-refresh is paused because this plugin is hidden. To keep its data fresh for other plugins, use the Plugin Merge strategy.
       refresh_paused_mashup: Refreshing Mashups
       refresh_paused_mashup_hint: Auto-refresh paused for fullscreen. Mashups are updating.
       refresh_stopped: Auto-refresh stopped. Please fix the plugin error to continue.

--- a/lib/trmnl/i18n/locales/web_ui/en.yml
+++ b/lib/trmnl/i18n/locales/web_ui/en.yml
@@ -622,7 +622,7 @@ en:
       synced: Synced
       refresh_paused: Refresh Paused
       refresh_paused_hint: Auto-refresh is paused. Add to playlist to start again.
-      refresh_paused_hidden_hint: Auto-refresh is paused because the plugin is hidden in the playlist. Data sync is active.
+      refresh_paused_hidden_hint: Auto-refresh is paused because this plugin is hidden. To keep its data fresh for other plugins, use the Plugin Merge strategy.
       refresh_paused_mashup: Refreshing Mashups
       refresh_paused_mashup_hint: Auto-refresh paused for fullscreen. Mashups are updating.
       refresh_stopped: Auto-refresh stopped. Please fix the plugin error to continue.

--- a/lib/trmnl/i18n/locales/web_ui/es-ES.yml
+++ b/lib/trmnl/i18n/locales/web_ui/es-ES.yml
@@ -623,7 +623,7 @@ es-ES:
       synced: Sincronizado
       refresh_paused: Actualización en pausa
       refresh_paused_hint: La actualización automática está en pausa. Añade a la lista para comenzar de nuevo.
-      refresh_paused_hidden_hint: La actualización automática está en pausa porque el plugin está oculto en la lista de reproducción. La sincronización de datos está activa.
+      refresh_paused_hidden_hint: Auto-refresh is paused because this plugin is hidden. To keep its data fresh for other plugins, use the Plugin Merge strategy.
       refresh_paused_mashup: Actualizando mashups
       refresh_paused_mashup_hint: Actualización automática pausada para pantalla completa. Mashups están actualizando.
       refresh_stopped: La actualización automática se ha detenido. Por favor, arregla el error del plugin para continuar.

--- a/lib/trmnl/i18n/locales/web_ui/fr.yml
+++ b/lib/trmnl/i18n/locales/web_ui/fr.yml
@@ -625,7 +625,7 @@ fr:
       synced: Synchronisé
       refresh_paused: Rafraîchissement en pause
       refresh_paused_hint: Le rafraîchissement automatique est en pause. Ajoutez à la playlist pour recommencer.
-      refresh_paused_hidden_hint: Le rafraîchissement auto est en pause car le plugin est masqué dans la playlist. La sync des données est active.
+      refresh_paused_hidden_hint: Auto-refresh is paused because this plugin is hidden. To keep its data fresh for other plugins, use the Plugin Merge strategy.
       refresh_paused_mashup: Rafraîchissement des combinaisons
       refresh_paused_mashup_hint: Rafraîchissement automatique en pause pour le plein écran. Les combinaisons se mettent à jour.
       refresh_stopped: Rafraîchissement automatique arrêté. Veuillez corriger l'erreur du plugin pour continuer.

--- a/lib/trmnl/i18n/locales/web_ui/he.yml
+++ b/lib/trmnl/i18n/locales/web_ui/he.yml
@@ -625,7 +625,7 @@ he:
       synced: Synced
       refresh_paused: Refresh Paused
       refresh_paused_hint: Auto-refresh is paused. Add to playlist to start again.
-      refresh_paused_hidden_hint: Auto-refresh is paused because the plugin is hidden in the playlist. Data sync is active.
+      refresh_paused_hidden_hint: Auto-refresh is paused because this plugin is hidden. To keep its data fresh for other plugins, use the Plugin Merge strategy.
       refresh_paused_mashup: Refreshing Mashups
       refresh_paused_mashup_hint: Auto-refresh paused for fullscreen. Mashups are updating.
       refresh_stopped: Auto-refresh stopped. Please fix the plugin error to continue.

--- a/lib/trmnl/i18n/locales/web_ui/hu.yml
+++ b/lib/trmnl/i18n/locales/web_ui/hu.yml
@@ -623,7 +623,7 @@ hu:
       synced: Szinkronizálva
       refresh_paused: Frissítés szüneteltetve
       refresh_paused_hint: Az automatikus frissítés szünetel. Add hozzá a lejátszási listához a folytatáshoz.
-      refresh_paused_hidden_hint: Az automatikus frissítés szünetel, mert a bővítmény el van rejtve a lejátszási listában. Az adatszinkron aktív.
+      refresh_paused_hidden_hint: Auto-refresh is paused because this plugin is hidden. To keep its data fresh for other plugins, use the Plugin Merge strategy.
       refresh_paused_mashup: Összevonások frissítése
       refresh_paused_mashup_hint: Az automatikus frissítés teljes képernyős módban szünetel. Az összevonások frissülnek.
       refresh_stopped: Az automatikus frissítés leállt. Kérlek, javítsd a bővítmény hibáját a folytatáshoz.

--- a/lib/trmnl/i18n/locales/web_ui/id.yml
+++ b/lib/trmnl/i18n/locales/web_ui/id.yml
@@ -625,7 +625,7 @@ id:
       synced: Synced
       refresh_paused: Refresh Paused
       refresh_paused_hint: Auto-refresh is paused. Add to playlist to start again.
-      refresh_paused_hidden_hint: Auto-refresh is paused because the plugin is hidden in the playlist. Data sync is active.
+      refresh_paused_hidden_hint: Auto-refresh is paused because this plugin is hidden. To keep its data fresh for other plugins, use the Plugin Merge strategy.
       refresh_paused_mashup: Refreshing Mashups
       refresh_paused_mashup_hint: Auto-refresh paused for fullscreen. Mashups are updating.
       refresh_stopped: Auto-refresh stopped. Please fix the plugin error to continue.

--- a/lib/trmnl/i18n/locales/web_ui/is.yml
+++ b/lib/trmnl/i18n/locales/web_ui/is.yml
@@ -623,7 +623,7 @@ is:
       synced: Samstillt
       refresh_paused: Uppfærsla í bið
       refresh_paused_hint: Sjálfvirk uppfærsla stöðvuð. Bættu við spilunarlista til að hefja aftur.
-      refresh_paused_hidden_hint: Sjálfvirk uppfærsla er á bið vegna þess að viðbótin er falin spilunarlista. Samstilling gagna er virk.
+      refresh_paused_hidden_hint: Auto-refresh is paused because this plugin is hidden. To keep its data fresh for other plugins, use the Plugin Merge strategy.
       refresh_paused_mashup: Uppfærsla á samsetningum
       refresh_paused_mashup_hint: Sjálfvirk uppfærsla í bið fyrir heilskjá. Samsetningar eru að uppfærast.
       refresh_stopped: Sjálfvirk uppfærsla stöðvuð. Lagfærðu villuna til að halda áfram.

--- a/lib/trmnl/i18n/locales/web_ui/it.yml
+++ b/lib/trmnl/i18n/locales/web_ui/it.yml
@@ -623,7 +623,7 @@ it:
       synced: Sincronizzato
       refresh_paused: Aggiornamento in pausa
       refresh_paused_hint: Aggiornamento automatico fermo. Aggiungi una playlist per avviarlo.
-      refresh_paused_hidden_hint: Auto-refresh is paused because the plugin is hidden in the playlist. Data sync is active.
+      refresh_paused_hidden_hint: Auto-refresh is paused because this plugin is hidden. To keep its data fresh for other plugins, use the Plugin Merge strategy.
       refresh_paused_mashup: Aggiornamento Mashups
       refresh_paused_mashup_hint: Aggiornamento automatico in pausa per schemo interno. Mashups si aggiornano.
       refresh_stopped: Aggiornamento automatico fermo. Correggi l'errore con il plugin per continuare.

--- a/lib/trmnl/i18n/locales/web_ui/ja.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ja.yml
@@ -623,7 +623,7 @@ ja:
       synced: 同期済み
       refresh_paused: Refresh Paused
       refresh_paused_hint: Auto-refresh is paused. Add to playlist to start again.
-      refresh_paused_hidden_hint: Auto-refresh is paused because the plugin is hidden in the playlist. Data sync is active.
+      refresh_paused_hidden_hint: Auto-refresh is paused because this plugin is hidden. To keep its data fresh for other plugins, use the Plugin Merge strategy.
       refresh_paused_mashup: Refreshing Mashups
       refresh_paused_mashup_hint: Auto-refresh paused for fullscreen. Mashups are updating.
       refresh_stopped: Auto-refresh stopped. Please fix the plugin error to continue.

--- a/lib/trmnl/i18n/locales/web_ui/ko.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ko.yml
@@ -623,7 +623,7 @@ ko:
       synced: 동기화됨
       refresh_paused: 새로고침 일시정지
       refresh_paused_hint: 자동 새로고침이 일시정지됐어요. 플레이리스트에 추가하면 다시 시작돼요.
-      refresh_paused_hidden_hint: 플레이리스트에서 플러그인이 숨겨져 있어서 자동 새로고침이 일시정지됐어요. 데이터 동기화는 계속돼요.
+      refresh_paused_hidden_hint: Auto-refresh is paused because this plugin is hidden. To keep its data fresh for other plugins, use the Plugin Merge strategy.
       refresh_paused_mashup: 매시업 새로고침 중
       refresh_paused_mashup_hint: 전체 화면에서 자동 새로고침이 일시정지됐어요. 매시업은 업데이트 중이에요.
       refresh_stopped: 자동 새로고침이 중지됐어요. 플러그인 오류를 수정해주세요.

--- a/lib/trmnl/i18n/locales/web_ui/lt.yml
+++ b/lib/trmnl/i18n/locales/web_ui/lt.yml
@@ -623,7 +623,7 @@ lt:
       synced: Sinchronizuota
       refresh_paused: Atnaujinimas sustabdytas
       refresh_paused_hint: Automatinis atnaujinimas pristabdytas. Pridėkite prie grojaraščio, kad paleistumėte vėl.
-      refresh_paused_hidden_hint: Automatinis atnaujinimas pristabdytas, nes įskiepis yra paslėptas grojaraštyje. Duomenų sinchronizavimas yra aktyvus.
+      refresh_paused_hidden_hint: Auto-refresh is paused because this plugin is hidden. To keep its data fresh for other plugins, use the Plugin Merge strategy.
       refresh_paused_mashup: Atnaujinami mišiniai (Mashups)
       refresh_paused_mashup_hint: Automatinis atnaujinimas pristabdytas viso ekrano režimui. Mišiniai atnaujinami.
       refresh_stopped: Automatinis atnaujinimas sustabdytas. Norėdami tęsti, ištaisykite įskiepio klaidą.

--- a/lib/trmnl/i18n/locales/web_ui/nl.yml
+++ b/lib/trmnl/i18n/locales/web_ui/nl.yml
@@ -623,7 +623,7 @@ nl:
       synced: Gesynchroniseerd
       refresh_paused: Verversen gepauzeerd
       refresh_paused_hint: Auto-verversen is paused. Add to playlist to start again.
-      refresh_paused_hidden_hint: Auto-refresh is paused because the plugin is hidden in the playlist. Data sync is active.
+      refresh_paused_hidden_hint: Auto-refresh is paused because this plugin is hidden. To keep its data fresh for other plugins, use the Plugin Merge strategy.
       refresh_paused_mashup: Mashups worden ververst
       refresh_paused_mashup_hint: Auto-verversen gepauzeerd voor fullscreen. Mashups worden geupdate.
       refresh_stopped: Auto-verversen gestopt. Los de plugin fouten op om door te gaan.

--- a/lib/trmnl/i18n/locales/web_ui/no.yml
+++ b/lib/trmnl/i18n/locales/web_ui/no.yml
@@ -623,7 +623,7 @@
       synced: Synkronisert
       refresh_paused: Refresh Paused
       refresh_paused_hint: Auto-refresh is paused. Add to playlist to start again.
-      refresh_paused_hidden_hint: Auto-refresh is paused because the plugin is hidden in the playlist. Data sync is active.
+      refresh_paused_hidden_hint: Auto-refresh is paused because this plugin is hidden. To keep its data fresh for other plugins, use the Plugin Merge strategy.
       refresh_paused_mashup: Refreshing Mashups
       refresh_paused_mashup_hint: Auto-refresh paused for fullscreen. Mashups are updating.
       refresh_stopped: Auto-refresh stopped. Please fix the plugin error to continue.

--- a/lib/trmnl/i18n/locales/web_ui/pl.yml
+++ b/lib/trmnl/i18n/locales/web_ui/pl.yml
@@ -645,7 +645,7 @@ pl:
       synced: Zsynchronizowany
       refresh_paused: Odświeżanie wstrzymane
       refresh_paused_hint: Automatyczne odświeżanie jest wstrzymane. Dodaj do playlisty, aby włączyć je z powrotem.
-      refresh_paused_hidden_hint: Automatyczne odświeżanie jest wstrzymane, bo plugin został ukryty na playliście. Synchronizacja danych jest aktywna.
+      refresh_paused_hidden_hint: Auto-refresh is paused because this plugin is hidden. To keep its data fresh for other plugins, use the Plugin Merge strategy.
       refresh_paused_mashup: Odświeżanie szablonów
       refresh_paused_mashup_hint: Automatyczne odświeżanie wstrzymane w trybie pełnoekranowym. Szablony się odświeżają.
       refresh_stopped: Automatyczne odświeżanie wstrzymane. Należy naprawić błędy w pluginie, nim będzie można kontynuować.

--- a/lib/trmnl/i18n/locales/web_ui/pt-BR.yml
+++ b/lib/trmnl/i18n/locales/web_ui/pt-BR.yml
@@ -623,7 +623,7 @@ pt-BR:
       synced: Sincronizado
       refresh_paused: Atualização Pausada
       refresh_paused_hint: Atualização pausada. Adicione na playlist para reiniciar.
-      refresh_paused_hidden_hint: Atualização pausada pois o plugin está escondido na playlist. Sincronização de dados ativa.
+      refresh_paused_hidden_hint: Auto-refresh is paused because this plugin is hidden. To keep its data fresh for other plugins, use the Plugin Merge strategy.
       refresh_paused_mashup: Atualizando Mashups
       refresh_paused_mashup_hint: Atualização pausada para tela cheia. Os mashups estão atualizando.
       refresh_stopped: Atualização desativada. Por favor corrija o erro do plugin para continuar.

--- a/lib/trmnl/i18n/locales/web_ui/ro.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ro.yml
@@ -623,7 +623,7 @@ ro:
       synced: Sincronizat
       refresh_paused: Reîmprospătare pausată
       refresh_paused_hint: Reîmprospătarea automată este pausată. Adaugă în lista de redare pentru a reporni.
-      refresh_paused_hidden_hint: Reîmprospătarea automată este pausată deoarece plugin-ul este ascuns în lista de redare. Sincronizarea datelor este activă.
+      refresh_paused_hidden_hint: Auto-refresh is paused because this plugin is hidden. To keep its data fresh for other plugins, use the Plugin Merge strategy.
       refresh_paused_mashup: Reîmprospătare mashup-uri
       refresh_paused_mashup_hint: Reîmprospătarea automată pausată pentru ecran complet. Mashup-urile se actualizează.
       refresh_stopped: Reîmprospătarea automată oprită. Rezolvă eroarea plugin-ului pentru a continua.

--- a/lib/trmnl/i18n/locales/web_ui/ru.yml
+++ b/lib/trmnl/i18n/locales/web_ui/ru.yml
@@ -645,7 +645,7 @@ ru:
       synced: Синхронизировано
       refresh_paused: Обновление приостановлено
       refresh_paused_hint: Автоматическое обновление приостановлено. Добавьте в плейлист, чтобы начать снова.
-      refresh_paused_hidden_hint: Автоматическое обновление приостановлено, потому что плагин скрыт в плейлисте. Синхронизация данных активна.
+      refresh_paused_hidden_hint: Auto-refresh is paused because this plugin is hidden. To keep its data fresh for other plugins, use the Plugin Merge strategy.
       refresh_paused_mashup: Обновление мэшапов
       refresh_paused_mashup_hint: Автоматическое обновление приостановлено для полноэкранного режима. Мэшапы обновляются.
       refresh_stopped: Автоматическое обновление остановлено. Исправьте ошибку плагина, чтобы продолжить.

--- a/lib/trmnl/i18n/locales/web_ui/sk.yml
+++ b/lib/trmnl/i18n/locales/web_ui/sk.yml
@@ -634,7 +634,7 @@ sk:
       synced: Synced
       refresh_paused: Refresh Paused
       refresh_paused_hint: Auto-refresh is paused. Add to playlist to start again.
-      refresh_paused_hidden_hint: Auto-refresh is paused because the plugin is hidden in the playlist. Data sync is active.
+      refresh_paused_hidden_hint: Auto-refresh is paused because this plugin is hidden. To keep its data fresh for other plugins, use the Plugin Merge strategy.
       refresh_paused_mashup: Refreshing Mashups
       refresh_paused_mashup_hint: Auto-refresh paused for fullscreen. Mashups are updating.
       refresh_stopped: Auto-refresh stopped. Please fix the plugin error to continue.

--- a/lib/trmnl/i18n/locales/web_ui/sv.yml
+++ b/lib/trmnl/i18n/locales/web_ui/sv.yml
@@ -623,7 +623,7 @@ sv:
       synced: Synced
       refresh_paused: Refresh Paused
       refresh_paused_hint: Auto-refresh is paused. Add to playlist to start again.
-      refresh_paused_hidden_hint: Auto-refresh is paused because the plugin is hidden in the playlist. Data sync is active.
+      refresh_paused_hidden_hint: Auto-refresh is paused because this plugin is hidden. To keep its data fresh for other plugins, use the Plugin Merge strategy.
       refresh_paused_mashup: Refreshing Mashups
       refresh_paused_mashup_hint: Auto-refresh paused for fullscreen. Mashups are updating.
       refresh_stopped: Auto-refresh stopped. Please fix the plugin error to continue.

--- a/lib/trmnl/i18n/locales/web_ui/uk.yml
+++ b/lib/trmnl/i18n/locales/web_ui/uk.yml
@@ -645,7 +645,7 @@ uk:
       synced: Synced
       refresh_paused: Refresh Paused
       refresh_paused_hint: Auto-refresh is paused. Add to playlist to start again.
-      refresh_paused_hidden_hint: Auto-refresh is paused because the plugin is hidden in the playlist. Data sync is active.
+      refresh_paused_hidden_hint: Auto-refresh is paused because this plugin is hidden. To keep its data fresh for other plugins, use the Plugin Merge strategy.
       refresh_paused_mashup: Refreshing Mashups
       refresh_paused_mashup_hint: Auto-refresh paused for fullscreen. Mashups are updating.
       refresh_stopped: Auto-refresh stopped. Please fix the plugin error to continue.

--- a/lib/trmnl/i18n/locales/web_ui/zh-CN.yml
+++ b/lib/trmnl/i18n/locales/web_ui/zh-CN.yml
@@ -658,7 +658,7 @@ zh-CN:
       synced: 已同步
       refresh_paused: 刷新已暂停
       refresh_paused_hint: 自动刷新已暂停。添加到播放列表以重新开始。
-      refresh_paused_hidden_hint: 由于插件在播放列表中已隐藏，自动刷新已暂停。数据同步仍处于活动状态。
+      refresh_paused_hidden_hint: Auto-refresh is paused because this plugin is hidden. To keep its data fresh for other plugins, use the Plugin Merge strategy.
       refresh_paused_mashup: 正在刷新混搭
       refresh_paused_mashup_hint: 全屏模式的自动刷新已暂停。混搭仍在更新。
       refresh_stopped: 自动刷新已停止。请修复插件错误以继续。

--- a/lib/trmnl/i18n/locales/web_ui/zh-HK.yml
+++ b/lib/trmnl/i18n/locales/web_ui/zh-HK.yml
@@ -623,7 +623,7 @@ zh-HK:
       synced: 已同步
       refresh_paused: 已暫停更新
       refresh_paused_hint: 自動更新已暫停，請加入至播放清單以重新開始。
-      refresh_paused_hidden_hint: 自動更新已暫停，因為此外掛在播放清單中被隱藏。數據同步仍會繼續。
+      refresh_paused_hidden_hint: Auto-refresh is paused because this plugin is hidden. To keep its data fresh for other plugins, use the Plugin Merge strategy.
       refresh_paused_mashup: 只更新混搭畫面
       refresh_paused_mashup_hint: 已暫停全螢幕的自動更新，混搭畫面(Mashup)仍會更新。
       refresh_stopped: 自動更新已停止。請修正外掛錯誤以繼續。


### PR DESCRIPTION
updates the hidden plugin refresh hint to point users to the plugin_merge strategy instead of saying data sync is active.

- en.yml: new copy for refresh_paused_hidden_hint
- resets the other web_ui locales to the new english so they get re-translated, raw left as-is